### PR TITLE
Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 ---
 language: python
-python: 2.7
-
 sudo: false
 
 cache: pip

--- a/pyidr/file_pattern.py
+++ b/pyidr/file_pattern.py
@@ -4,10 +4,13 @@ Bio-Formats style file patterns.
 www.openmicroscopy.org/site/support/bio-formats5.1/formats/pattern-file.html
 """
 
+from builtins import map
+from builtins import range
+from builtins import object
 import re
 import string
 import difflib
-from itertools import product, izip_longest
+from itertools import product, zip_longest
 
 
 class InvertedRangeError(Exception):
@@ -24,7 +27,7 @@ def _expand_letter_range(start, stop, step):
     stop = letters.index(stop) + 1
     if stop <= start:
         raise InvertedRangeError
-    return [letters[_] for _ in xrange(start, stop, step)]
+    return [letters[_] for _ in range(start, stop, step)]
 
 
 def expand_range(r):
@@ -57,10 +60,10 @@ def expand_range(r):
             raise ValueError("inverted range: %s" % r)
         step = int(step)
         if len(start_str) != len(stop_str):
-            return map(str, range(start, stop, step))
+            return list(map(str, list(range(start, stop, step))))
         else:
             fmt = "%%0%dd" % len(start_str)
-            return [fmt % _ for _ in xrange(start, stop, step)]
+            return [fmt % _ for _ in range(start, stop, step)]
 
 
 def expand_block(block):
@@ -87,11 +90,11 @@ def find_pattern_2seq(s1, s2):
     sm = difflib.SequenceMatcher(None, s1, s2, False)
     blocks = sm.get_matching_blocks()
     pattern = [(sm.a[:blocks[0].a], sm.b[:blocks[0].b])]
-    for i in xrange(len(blocks) - 1):
+    for i in range(len(blocks) - 1):
         l, r = blocks[i], blocks[i+1]
         pattern.append(sm.a[l.a:l.a+l.size])
         pattern.append((sm.a[l.a+l.size:r.a], sm.b[l.b+l.size:r.b]))
-    for i in xrange(len(pattern) - 1, -1, -1):
+    for i in range(len(pattern) - 1, -1, -1):
         if isinstance(pattern[i], tuple):
             if set(pattern[i]) == {""}:
                 del pattern[i]
@@ -111,4 +114,4 @@ class FilePattern(object):
     def filenames(self):
         fixed = re.split(r"<.+?>", self.pattern)
         for repl in product(*(expand_block(_) for _ in self.blocks())):
-            yield "".join(sum(izip_longest(fixed, repl, fillvalue=""), ()))
+            yield "".join(sum(zip_longest(fixed, repl, fillvalue=""), ()))

--- a/pyidr/file_pattern.py
+++ b/pyidr/file_pattern.py
@@ -22,7 +22,8 @@ def _expand_letter_range(start, stop, step):
         raise ValueError("non-literal range: %s-%s" % (start, stop))
     if (start.isupper() != stop.isupper()):
         raise ValueError("mixed case range: %s-%s" % (start, stop))
-    letters = string.ascii_uppercase if start.isupper() else string.ascii_lowercase
+    letters = (
+        string.ascii_uppercase if start.isupper() else string.ascii_lowercase)
     start = letters.index(start)
     stop = letters.index(stop) + 1
     if stop <= start:

--- a/pyidr/file_pattern.py
+++ b/pyidr/file_pattern.py
@@ -4,7 +4,6 @@ Bio-Formats style file patterns.
 www.openmicroscopy.org/site/support/bio-formats5.1/formats/pattern-file.html
 """
 
-from builtins import map
 from builtins import range
 from builtins import object
 import re

--- a/pyidr/file_pattern.py
+++ b/pyidr/file_pattern.py
@@ -61,7 +61,7 @@ def expand_range(r):
             raise ValueError("inverted range: %s" % r)
         step = int(step)
         if len(start_str) != len(stop_str):
-            return list(map(str, list(range(start, stop, step))))
+            return [str(x) for x in range(start, stop, step)]
         else:
             fmt = "%%0%dd" % len(start_str)
             return [fmt % _ for _ in range(start, stop, step)]

--- a/pyidr/file_pattern.py
+++ b/pyidr/file_pattern.py
@@ -22,7 +22,7 @@ def _expand_letter_range(start, stop, step):
         raise ValueError("non-literal range: %s-%s" % (start, stop))
     if (start.isupper() != stop.isupper()):
         raise ValueError("mixed case range: %s-%s" % (start, stop))
-    letters = string.uppercase if start.isupper() else string.lowercase
+    letters = string.ascii_uppercase if start.isupper() else string.ascii_lowercase
     start = letters.index(start)
     stop = letters.index(stop) + 1
     if stop <= start:

--- a/pyidr/screenio.py
+++ b/pyidr/screenio.py
@@ -46,7 +46,7 @@ class ScreenWriter(ScreenIO):
         self.fields = int(fields)
         self.screen_name = screen_name
         self.exclude_readers = exclude_readers
-        self.alpha_map = dict(enumerate(string.uppercase))
+        self.alpha_map = dict(enumerate(string.ascii_uppercase))
         self.reset()
 
     def reset(self):

--- a/pyidr/screenio.py
+++ b/pyidr/screenio.py
@@ -1,5 +1,9 @@
+from future import standard_library
+standard_library.install_aliases()
+from builtins import range
+from builtins import object
 import string
-import ConfigParser
+import configparser
 import abc
 
 
@@ -46,7 +50,7 @@ class ScreenWriter(ScreenIO):
         self.reset()
 
     def reset(self):
-        self.cp = ConfigParser.ConfigParser()
+        self.cp = configparser.ConfigParser()
         self.cp.optionxform = str  # case-sensitive option names
         self.__add_plate_entry()
         self.__well_count = 0
@@ -90,7 +94,7 @@ class ScreenWriter(ScreenIO):
         self.cp.add_section(sec)
         self.cp.set(sec, "Row", "%d" % i)
         self.cp.set(sec, "Column", "%d" % j)
-        for k, v in extra_kv.iteritems():
+        for k, v in extra_kv.items():
             self.cp.set(sec, k, v)
         for f, v in enumerate(field_values):
             if v:
@@ -106,7 +110,7 @@ class ScreenReader(ScreenIO):
     def __init__(self, f):
         super(ScreenReader, self).__init__()
         self.__f = f
-        self.cp = ConfigParser.ConfigParser()
+        self.cp = configparser.ConfigParser()
         self.cp.optionxform = str
         self.wells = []
         self.__read()
@@ -123,7 +127,7 @@ class ScreenReader(ScreenIO):
         getter = getattr(self.cp, getter_name)
         try:
             return getter(sec, opt)
-        except ConfigParser.NoOptionError:
+        except configparser.NoOptionError:
             raise ScreenError("Required %r option missing in %r" % (opt, sec))
 
     def get(self, sec, opt):
@@ -138,7 +142,7 @@ class ScreenReader(ScreenIO):
     def __read(self):
         self.cp.readfp(self.__f)
         self.__read_plate()
-        for idx in xrange(self.rows * self.columns):
+        for idx in range(self.rows * self.columns):
             self.__read_well(idx)
 
     def __read_plate(self):
@@ -164,7 +168,7 @@ class ScreenReader(ScreenIO):
             )
         w = dict(self.cp.items(sec))
         fields = []
-        for i in xrange(self.fields):
+        for i in range(self.fields):
             field_key = "Field_%d" % i
             try:
                 fields.append(self.get(sec, field_key))

--- a/pyidr/screenio.py
+++ b/pyidr/screenio.py
@@ -1,5 +1,5 @@
-from future import standard_library
-standard_library.install_aliases()
+#!/usr/bin/env python
+
 from builtins import range
 from builtins import object
 import string

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -1,5 +1,10 @@
 #! /usr/bin/env python
 
+from __future__ import print_function
+from builtins import str
+from builtins import zip
+from builtins import range
+from builtins import object
 from argparse import ArgumentParser
 import glob
 import json
@@ -88,7 +93,7 @@ class StudyError(Exception):
     pass
 
 
-class StudyParser():
+class StudyParser(object):
 
     def __init__(self, study_file):
         self._study_file = study_file
@@ -381,7 +386,7 @@ class Formatter(object):
                     value = formatter % d
                     for v in value.split('\t'):
                         s.append({'%s' % key: v})
-                except KeyError, e:
+                except KeyError as e:
                     self.log.debug("Missing %s" % e.message)
 
         s = []
@@ -434,7 +439,7 @@ class Formatter(object):
                 self.log.info("Deleting client map annotation")
                 ann._conn.deleteObjects('Annotation', [ann.id])
 
-        expected_pairs = [(k, v) for i in d["map"] for k, v in i.iteritems()]
+        expected_pairs = [(k, v) for i in d["map"] for k, v in i.items()]
         status = self.check_annotation(
             obj, expected_pairs, STUDY_NS, update=update)
         return status
@@ -574,12 +579,12 @@ def main(argv):
                     else:
                         log.warn("Unknown key: %s", key)
         if unknown:
-            print "Found %s unknown keys:" % len(unknown)
+            print("Found %s unknown keys:" % len(unknown))
             raise Exception("\n".join(unknown))
         d = Formatter(p, inspect=args.inspect)
 
         if args.report:
-            print str(d)
+            print(str(d))
 
         if args.check or args.set:
             d.check(update=args.set)

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -368,7 +368,7 @@ class Formatter(object):
         else:
             key = "Study Description"
         component_title = (
-            "%s\n%s" % (key, component[key])).decode('string_escape')
+            "%s\n%s" % (key, component[key]))
         if "Study Version History" in component:
             history = ("\n\nVersion History\n%s" %
                        component["Study Version History"])
@@ -387,7 +387,7 @@ class Formatter(object):
                     for v in value.split('\t'):
                         s.append({'%s' % key: v})
                 except KeyError as e:
-                    self.log.debug("Missing %s" % e.message)
+                    self.log.debug("Missing %s" % str(e))
 
         s = []
         if component.get("Type", None) == "Experiment":

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -576,7 +576,7 @@ def main(argv):
                     if args.strict:
                         unknown.append(key)
                     else:
-                        log.warn("Unknown key: %s", key)
+                        log.warning("Unknown key: %s", key)
         if unknown:
             print("Found %s unknown keys:" % len(unknown))
             raise Exception("\n".join(unknown))

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -1,6 +1,5 @@
 #! /usr/bin/env python
 
-from __future__ import print_function
 from builtins import str
 from builtins import zip
 from builtins import range

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -553,6 +553,9 @@ def main(argv):
     parser.add_argument(
         '--verbose', '-v', action='count', default=0,
         help='Increase the command verbosity')
+    parser.add_argument(
+        '--quiet', '-q', action='count', default=0,
+        help='Decrease the command verbosity')
     group = parser.add_mutually_exclusive_group()
     group.add_argument("--check", action="store_true",
                        help="Check the study annotations on IDR")
@@ -560,7 +563,8 @@ def main(argv):
                        help="Set the study annotations on IDR")
     args = parser.parse_args(argv)
 
-    logging.basicConfig(level=logging.WARN - 10 * args.verbose)
+    logging.basicConfig(
+        level=logging.WARN - 10 * args.verbose + 10 * args.quiet)
     log = logging.getLogger("pyidr.study_parser")
 
     for s in args.studyfile:

--- a/scripts/annotate/missing_image_annotations.py
+++ b/scripts/annotate/missing_image_annotations.py
@@ -6,7 +6,7 @@ import os
 
 
 def printusage():
-    print ('''
+    print('''
 Checks for Images which have been imported but don't have any annotations.
 Will skip Datasets which are not mentioned in the annotation.csv.
 

--- a/scripts/annotate/missing_well_annotations.py
+++ b/scripts/annotate/missing_well_annotations.py
@@ -6,7 +6,7 @@ import os
 
 
 def printusage():
-    print ('''
+    print('''
 Checks for Wells which have been imported but don't have any annotations.
 Will skip Plates which are not mentioned in the annotation.csv.
 

--- a/scripts/celery/calc.py
+++ b/scripts/celery/calc.py
@@ -20,7 +20,9 @@ containing a list of (subdir, file) pairs as whitespace-separated
 basenames, e.g., "plate1\tplate1_0.avro". Tasks will be submitted only
 for the specified pairs.
 """
+from __future__ import print_function
 
+from builtins import str
 import sys
 import os
 import argparse
@@ -130,7 +132,7 @@ def main(argv):
             celery_args = get_celery_args(args, calc_opts, subdir_bn, avro_bn)
 
             if args.dry_run:
-                print celery_args
+                print(celery_args)
             else:
                 r = celery.send_task('tasks.run_docker', kwargs=celery_args)
                 fo.write(str(r) + "\n")

--- a/scripts/celery/calc.py
+++ b/scripts/celery/calc.py
@@ -20,7 +20,6 @@ containing a list of (subdir, file) pairs as whitespace-separated
 basenames, e.g., "plate1\tplate1_0.avro". Tasks will be submitted only
 for the specified pairs.
 """
-from __future__ import print_function
 
 from builtins import str
 import sys

--- a/scripts/celery/get_failed.py
+++ b/scripts/celery/get_failed.py
@@ -22,8 +22,8 @@ for line in sys.stdin:
             fail[taskid] = r
 
 print('SUMMARY')
-for k, v in list(st.items()):
+for k, v in st.items():
     print('  {}: {}'.format(k, v))
 print('\nFAILURES')
-for k, v in list(fail.items()):
+for k, v in fail.items():
     print('  {}: {}'.format(k, v.info))

--- a/scripts/celery/get_failed.py
+++ b/scripts/celery/get_failed.py
@@ -5,7 +5,6 @@
 #
 #   ./get_failed.py < taskids.txt
 
-from __future__ import print_function
 import celery.result
 import sys
 

--- a/scripts/celery/get_failed.py
+++ b/scripts/celery/get_failed.py
@@ -5,6 +5,7 @@
 #
 #   ./get_failed.py < taskids.txt
 
+from __future__ import print_function
 import celery.result
 import sys
 
@@ -22,8 +23,8 @@ for line in sys.stdin:
             fail[taskid] = r
 
 print('SUMMARY')
-for k, v in st.items():
+for k, v in list(st.items()):
     print('  {}: {}'.format(k, v))
 print('\nFAILURES')
-for k, v in fail.items():
+for k, v in list(fail.items()):
     print('  {}: {}'.format(k, v.info))

--- a/scripts/check_screen.py
+++ b/scripts/check_screen.py
@@ -9,7 +9,6 @@ If everything is OK, there is no output and the return value is zero.
 Otherwise, the return value is nonzero and you should see something on
 stderr.
 """
-from __future__ import print_function
 
 import sys
 import os

--- a/scripts/check_screen.py
+++ b/scripts/check_screen.py
@@ -9,6 +9,7 @@ If everything is OK, there is no output and the return value is zero.
 Otherwise, the return value is nonzero and you should see something on
 stderr.
 """
+from __future__ import print_function
 
 import sys
 import os
@@ -40,7 +41,7 @@ def main(argv):
     retval = 0
     args = parse_cl(argv)
     if args.verbose:
-        print "checking %r" % (args.screen,)
+        print("checking %r" % (args.screen,))
     with open(args.screen) as f:
         reader = ScreenReader(f)
     # ScreenReader raises an exception if the file is not well-formed
@@ -52,9 +53,9 @@ def main(argv):
             retval = 1
             if args.verbose:
                 sys.stderr.write("ERROR[%d|%d]: missing %r\n" % (i, j, fn))
-    print "files: %d%s" % (
+    print("files: %d%s" % (
         count + 1, " (missing: %d)" % missing if args.check_existence else ""
-    )
+    ))
     return retval
 
 

--- a/scripts/gen_screens_0016_0036/make_screen.py
+++ b/scripts/gen_screens_0016_0036/make_screen.py
@@ -23,6 +23,8 @@ a01 to p24 and FIELD_TAG ranges from s1 to s6:
   cdp2bioactives_p24_s6_w2a2bb6fea-13ae-4645-ae08-ef64ae92c281.tif
 """
 
+from builtins import zip
+from builtins import range
 import sys
 import os
 import re
@@ -54,7 +56,7 @@ def get_channel_map(data_dir):
             continue
         plate_tag, channel_tag = subd.strip().split("-")
         channel_map.setdefault(plate_tag, []).append(channel_tag)
-    for v in channel_map.itervalues():
+    for v in channel_map.values():
         v.sort()
     return channel_map
 
@@ -94,7 +96,7 @@ def get_file_map(subd):
             continue
         field_idx = int(m.groups()[0])
         file_map.setdefault(well_tag, []).append((field_idx, fn))
-    for k, v in file_map.iteritems():
+    for k, v in file_map.items():
         v.sort()
         last_field_indices.append(v[-1][0])
         file_map[k] = [_[1] for _ in v]
@@ -117,7 +119,7 @@ def write_screen(data_dir, plate, outf, screen=None):
     n_fields = max(n_fields)
     base_path = os.path.join(data_dir, "%s-" % plate)
     writer = ScreenWriter(plate, ROWS, COLUMNS, n_fields, **kwargs)
-    for idx in xrange(ROWS * COLUMNS):
+    for idx in range(ROWS * COLUMNS):
         well_tag = "%s%02d" % writer.coordinates(idx)
         if not any(well_tag in file_maps[_] for _ in channel_tags):
             sys.stderr.write(
@@ -126,7 +128,7 @@ def write_screen(data_dir, plate, outf, screen=None):
             writer.add_well([])
             continue
         field_values = []
-        for i in xrange(n_fields):
+        for i in range(n_fields):
             try:
                 fnames = [file_maps[_][well_tag][i] for _ in channel_tags]
             except IndexError:

--- a/scripts/git-restore-mtime-bare.py
+++ b/scripts/git-restore-mtime-bare.py
@@ -66,7 +66,7 @@ for line in gitobj.stdout:
 
     # Date line
     else:
-        mtime = long(line)
+        mtime = int(line)
 
     # All files done?
     if not filelist:

--- a/scripts/nginx_parse.py
+++ b/scripts/nginx_parse.py
@@ -8,6 +8,8 @@
 # On stderr, monthly totals will be output after each month. At the
 # end, global stats will be printed.
 
+from __future__ import print_function
+from builtins import input
 from sys import stderr
 from fileinput import input
 from re import compile
@@ -38,15 +40,15 @@ def print_month(month, per_month):
     ips, hits = tuple(per_month)
     if ips or hits:
         msg = "%s Month totals: IPs=%s Hits=%s" % (month, len(ips), hits)
-        print >>stderr, msg
+        print(msg, file=stderr)
 
 
 data = defaultdict(lambda: defaultdict(int))
-for line in input():
+for line in eval(input()):
     line = line.strip()
     m = pattern.match(line)
     if not m:
-        print "skipping", line
+        print(("skipping", line))
         continue
     g = m.groups()
     d = dt_parse(g[1])
@@ -67,7 +69,7 @@ for k, v in sorted(data.items()):
         total_ips.add(ip)
         per_month[1] += count
         per_month[0].add(ip)
-        print k, ip, count
+        print((k, ip, count))
 print_month(k, per_month)  # Leftovers
-print >>stderr, "Total hits:", total_hits
-print >>stderr, "Unique IPs:", len(total_ips)
+print("Total hits:", total_hits, file=stderr)
+print("Unique IPs:", len(total_ips), file=stderr)

--- a/scripts/nginx_parse.py
+++ b/scripts/nginx_parse.py
@@ -8,7 +8,6 @@
 # On stderr, monthly totals will be output after each month. At the
 # end, global stats will be printed.
 
-from builtins import input
 from sys import stderr
 from fileinput import input
 from re import compile

--- a/scripts/nginx_parse.py
+++ b/scripts/nginx_parse.py
@@ -8,7 +8,6 @@
 # On stderr, monthly totals will be output after each month. At the
 # end, global stats will be printed.
 
-from __future__ import print_function
 from builtins import input
 from sys import stderr
 from fileinput import input

--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+from builtins import str
+from builtins import input
+from builtins import map
 from collections import defaultdict
 from fileinput import input
 from fileinput import hook_compressed
@@ -97,7 +101,7 @@ def studies():
 
                 if not exists(p) and exists("%s.gz" % p):
                     p = "%s.gz" % p
-                for line in input([p], openhook=hook_compressed):
+                for line in eval(input([p], openhook=hook_compressed)):
                     parts = line.strip().split("\t")
                     if name_idx:
                         name = parts[name_idx]
@@ -125,14 +129,14 @@ def orphans(query):
         "where ws = null "
         "order by f.id"), None))
     for orphan in orphans:
-        print "Fileset:%s" % (orphan[0])
-    print >>stderr, "Total:", len(orphans)
+        print("Fileset:%s" % (orphan[0]))
+    print("Total:", len(orphans), file=stderr)
 
 
 def unknown(query):
     on_disk = []
     for study, screens in sorted(studies().items()):
-        for screen, plates in screens.items():
+        for screen, plates in list(screens.items()):
             on_disk.append(screen)
             on_disk.extend(plates)
 
@@ -140,24 +144,24 @@ def unknown(query):
         "select s.name, s.id from Screen s"), None))
     for name, id in on_server:
         if name not in on_disk:
-            print "Screen:%s" % id, name
+            print("Screen:%s" % id, name)
 
     on_server = unwrap(query.projection((
         "select s.name, p.name, p.id from Plate p "
         "join p.screenLinks as sl join sl.parent as s"), None))
     for screen, name, id in on_server:
         if name not in on_disk:
-            print "Plate:%s" % id, name, screen
+            print("Plate:%s" % id, name, screen)
 
 
 def check_search(query, search):
     obj_types = ('Screen', 'Plate', 'Image')
-    print "loading all map annotations"
+    print("loading all map annotations")
     res = query.findAllByQuery("from MapAnnotation m", None)
     all_values = set(
-        v for m in res for k, v in m.getMapValueAsMap().iteritems()
+        v for m in res for k, v in m.getMapValueAsMap().items()
     )
-    print "searching for all unique values [%d]" % len(all_values)
+    print("searching for all unique values [%d]" % len(all_values))
     with open("no_matches.txt", "w") as fo:
         for v in all_values:
             try:
@@ -195,7 +199,7 @@ def stat_screens(query):
                 expected = set_expected["Dataset"]
                 rv = unwrap(query.projection(PDI_QUERY, params))
             else:
-                raise Exception("unknown: %s" % set_expected.keys())
+                raise Exception("unknown: %s" % list(set_expected.keys()))
 
             if not rv:
                 tb.row(container, "MISSING", "", "", "", "", "")
@@ -217,7 +221,7 @@ def stat_screens(query):
                            filesizeformat(bytes))
     tb.row("Total", "", plate_count, well_count, image_count, plane_count,
            filesizeformat(byte_count))
-    print str(tb.build())
+    print(str(tb.build()))
 
 
 def stat_plates(query, screen, images=False):
@@ -243,7 +247,7 @@ def stat_plates(query, screen, images=False):
         count = unwrap(query.projection(
             q % "count(distinct i.id)", params
         ))[0][0]
-        print >>stderr, count
+        print(count, file=stderr)
         params.page(0, limit)
 
         q = q % "distinct i.id"
@@ -258,7 +262,7 @@ def stat_plates(query, screen, images=False):
         return
 
     plates = glob(join(screen, "plates", "*"))
-    plates = map(basename, plates)
+    plates = list(map(basename, plates))
 
     tb = TableBuilder("Plate")
     tb.cols(["PID", "Wells", "Images"])
@@ -285,12 +289,12 @@ def stat_plates(query, screen, images=False):
                 image_count += images
                 tb.row(plate, plate_id, wells, images)
     tb.row("Total", "", well_count, image_count)
-    print str(tb.build())
+    print(str(tb.build()))
 
 
 def copy(client, copy_from, copy_type, copy_to):
     gateway = BlitzGateway(client_obj=client)
-    print gateway.applySettingsToSet(copy_from, copy_type, [copy_to])
+    print(gateway.applySettingsToSet(copy_from, copy_type, [copy_to]))
     gateway.getObject("Image", copy_to).getThumbnail(size=(96,), direct=False)
 
 
@@ -301,9 +305,9 @@ def main():
     parser.add_argument("--unknown", action="store_true")
     parser.add_argument("--search", action="store_true")
     parser.add_argument("--images", action="store_true")
-    parser.add_argument("--copy-from", type=long, default=None)
+    parser.add_argument("--copy-from", type=int, default=None)
     parser.add_argument("--copy-type", default="Image")
-    parser.add_argument("--copy-to", type=long, default=None)
+    parser.add_argument("--copy-to", type=int, default=None)
     parser.add_argument("screen", nargs="?")
     ns = parser.parse_args()
 
@@ -326,7 +330,7 @@ def main():
                 copy(client, ns.copy_from, ns.copy_type, ns.copy_to)
             else:
                 for x in stat_plates(query, ns.screen, ns.images):
-                    print x
+                    print(x)
     finally:
         cli.close()
 

--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 from builtins import str
 from builtins import input
 from builtins import map

--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 from builtins import str
-from builtins import input
 from builtins import map
 from collections import defaultdict
 from fileinput import input

--- a/scripts/travis-check.py
+++ b/scripts/travis-check.py
@@ -6,6 +6,7 @@ Recursively checks YAML and CSV files for validity
 YAML docs should contain a single document
 CSVs should have unique column names and be loadable with pandas
 """
+from __future__ import print_function
 
 import os
 import pandas
@@ -27,12 +28,12 @@ for root, dirs, files in os.walk(REPO_ROOT):
             continue
 
         if fn.lower().endswith('.yml') or fn.lower().endswith('.yaml'):
-            print fn
+            print(fn)
             docs = list(yaml.load_all(f))
             assert len(docs) == 1
 
         if fn.lower().endswith('.csv'):
-            print fn
+            print(fn)
             # pandas is way too tolerant of extra columns- they may be treated
             # as a single or multi row index, or discarded. Since we don't
             # use index columns the following seems to be the best way of

--- a/scripts/travis-check.py
+++ b/scripts/travis-check.py
@@ -6,7 +6,6 @@ Recursively checks YAML and CSV files for validity
 YAML docs should contain a single document
 CSVs should have unique column names and be loadable with pandas
 """
-from __future__ import print_function
 
 import os
 import pandas

--- a/scripts/tsv_plates.py
+++ b/scripts/tsv_plates.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 from sys import stderr
 from os.path import basename
 from os.path import exists
@@ -22,9 +23,9 @@ def main(output, inputs):
     with open(output, "a") as out:
         for line in get_lines():
             if line in existing:
-                print >>stderr, "Dupe: ", line
+                print("Dupe: ", line, file=stderr)
             else:
-                print >>out, line
+                print(line, file=out)
 
 
 if __name__ == "__main__":

--- a/scripts/tsv_plates.py
+++ b/scripts/tsv_plates.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 from sys import stderr
 from os.path import basename
 from os.path import exists

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     classifiers=CLASSIFIERS,
     packages=["pyidr"],
     install_requires=[
+        "future",
         "PyYAML",
         "pandas<0.19",
         "flake8",

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     version="0.1.dev",
     classifiers=CLASSIFIERS,
     packages=["pyidr"],
+    python_requires='>=3',
     install_requires=[
         "future",
         "PyYAML",

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     name=NAME,
     description=DESCRIPTION,
     url=URL,
-    version="0.1.dev",
+    version="0.2.dev1",
     classifiers=CLASSIFIERS,
     packages=["pyidr"],
     python_requires='>=3',

--- a/test/test_screenio.py
+++ b/test/test_screenio.py
@@ -1,5 +1,5 @@
-from future import standard_library
-standard_library.install_aliases()
+#!/usr/bin/env python
+
 from builtins import str
 from builtins import range
 import os

--- a/test/test_screenio.py
+++ b/test/test_screenio.py
@@ -1,7 +1,11 @@
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import range
 import os
 import unittest
-from cStringIO import StringIO
-import ConfigParser
+from io import StringIO
+import configparser
 
 from pyidr.screenio import ScreenWriter, ScreenReader, ScreenError
 
@@ -16,7 +20,7 @@ class TestScreenIO(unittest.TestCase):
 
     def _field_values(self, idx):
         values = [
-            "%s_%d_%d.fake" % (self.name, idx, _) for _ in xrange(self.fields)
+            "%s_%d_%d.fake" % (self.name, idx, _) for _ in range(self.fields)
         ]
         self.all_field_values.append(values)
         return values
@@ -36,17 +40,17 @@ class TestScreenWriter(TestScreenIO):
         writer = ScreenWriter(
             self.name, self.rows, self.columns, self.fields, **kwargs
         )
-        for i in xrange(self.size):
+        for i in range(self.size):
             writer.add_well(self._field_values(i), extra_kv=self.extra_kv)
         writer.write(fout)
         fout.seek(0)
-        self.cp = ConfigParser.ConfigParser()
+        self.cp = configparser.ConfigParser()
         self.cp.readfp(fout)
 
     def test_sections(self):
         self.assertEqual(
             self.cp.sections(),
-            ['Plate'] + ['Well %d' % _ for _ in xrange(self.size)]
+            ['Plate'] + ['Well %d' % _ for _ in range(self.size)]
         )
 
     def test_plate(self):
@@ -67,24 +71,24 @@ class TestScreenWriter(TestScreenIO):
             self.assertEqual(self.cp.get(sec, "ScreenName"), self.screen_name)
         else:
             self.assertRaises(
-                ConfigParser.NoOptionError, self.cp.get, sec, "ScreenName"
+                configparser.NoOptionError, self.cp.get, sec, "ScreenName"
             )
 
     def test_wells(self):
-        for i in xrange(self.rows):
-            for j in xrange(self.columns):
+        for i in range(self.rows):
+            for j in range(self.columns):
                 idx = i * self.columns + j
                 sec = 'Well %d' % idx
                 self.assertTrue(self.cp.has_section(sec))
                 for k, v in [("Row", i), ("Column", j)]:
                     self.assertTrue(self.cp.has_option(sec, k))
                     self.assertEqual(self.cp.get(sec, k), str(v))
-                for f in xrange(self.fields):
+                for f in range(self.fields):
                     k = 'Field_%d' % f
                     self.assertTrue(self.cp.has_option(sec, k))
                     self.assertEqual(self.cp.get(sec, k),
                                      self.all_field_values[idx][f])
-                    for ek, ev in self.extra_kv.iteritems():
+                    for ek, ev in self.extra_kv.items():
                         self.assertTrue(self.cp.has_option(sec, ek))
                         self.assertEqual(self.cp.get(sec, ek), ev)
 
@@ -109,8 +113,8 @@ class TestScreenReader(TestScreenIO):
         if screen_name:
             self.conf_lines.append("ScreenName = %s" % screen_name)
         self.conf_lines.append("")
-        for i in xrange(self.rows):
-            for j in xrange(self.columns):
+        for i in range(self.rows):
+            for j in range(self.columns):
                 idx = (i * self.columns + j)
                 self.conf_lines.extend([
                     "[Well %d]" % idx,
@@ -143,7 +147,7 @@ class TestScreenReaderName(TestScreenReader):
 class TestScreenReaderBad(unittest.TestCase):
 
     def test_bad_conf(self):
-        self.assertRaises(ConfigParser.Error, ScreenReader, StringIO("foo"))
+        self.assertRaises(configparser.Error, ScreenReader, StringIO("foo"))
 
     def test_missing_sections(self):
         missing_well = os.linesep.join([
@@ -165,7 +169,7 @@ class TestScreenReaderBad(unittest.TestCase):
             "Columns = 0",
             "Fields = 0",
         ]
-        for i in xrange(1, len(conf_lines)):
+        for i in range(1, len(conf_lines)):
             copy = conf_lines[:]
             del copy[i]
             bad_f = StringIO(os.linesep.join(copy))
@@ -179,7 +183,7 @@ class TestScreenReaderBad(unittest.TestCase):
             "Columns = 0",
             "Fields = 0",
         ]
-        for i in xrange(2, len(conf_lines)):
+        for i in range(2, len(conf_lines)):
             copy = conf_lines[:]
             copy[i] = copy[i].replace("0", "0.5")
             bad_f = StringIO(os.linesep.join(copy))


### PR DESCRIPTION
Upgrade the IDR utility scripts to be Python 3 compatible and fix the study parser utility with OMERO 5.6.


- 993d8b8 was originally generated by running `futurize -w -n .`
- the other commits were tested while updating the annotations on `prod80`. The outcome of these changes can be tested on a local server by running

  ```
   $ git clone git://github.com/sbesson/idr-utils -b python3
   $ /opt/omero/server/venv3/bin/omero login public@localhost -w public
   $ find /uod/idr/metadata/ -type f -name '*study.txt' | sort | xargs /opt/omero/server/venv3/bin/python pyidr/study_parser.py --check -q
  ```

The `stats.py` and other scripts should be minimally functional but have not been tested yet and might need additional tweaks outside the scope of this PR