### PR TITLE
Add support for EMPIAR accessions

### DIFF
--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -315,9 +315,8 @@ class Formatter(object):
         ('BioStudies Accession', "%(Study BioStudies Accession)s"
          " https://www.ebi.ac.uk/biostudies/studies/"
          "%(Study BioStudies Accession)s"),
-        ('EMPIAR Accession', "EMPIAR-%(Study EMPIAR Accession)s"
-         " https://www.ebi.ac.uk/pdbe/emdb/empiar/entry/"
-         "%(Study EMPIAR Accession)s"),
+        ('EMPIAR Accession', "%(Study EMPIAR Accession)s"
+         " https://dx.doi.org/10.6019/%(Study EMPIAR Accession)s"),
     ]
     ANNOTATION_PAIRS = [('Annotation File', "%(Annotation File)s")]
 

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -40,6 +40,7 @@ KEYS = (
     # OPTIONAL_KEYS["Study"]
     Key('Study Version History', 'Study', optional=True),
     Key('Study BioStudies Accession', 'Study', optional=True),
+    Key('Study EMPIAR Accession', 'Study', optional=True),
     Key('Study Publication Preprint', 'Study', optional=True),
     Key('Study PubMed ID', 'Study', optional=True),
     Key('Study PMC ID', 'Study', optional=True),
@@ -314,6 +315,9 @@ class Formatter(object):
         ('BioStudies Accession', "%(Study BioStudies Accession)s"
          " https://www.ebi.ac.uk/biostudies/studies/"
          "%(Study BioStudies Accession)s"),
+        ('EMPIAR Accession', "EMPIAR-%(Study EMPIAR Accession)s"
+         " https://www.ebi.ac.uk/pdbe/emdb/empiar/entry/"
+         "%(Study EMPIAR Accession)s"),
     ]
     ANNOTATION_PAIRS = [('Annotation File', "%(Annotation File)s")]
 


### PR DESCRIPTION
In some cases, IDR studies might be also be available from EMPIAR so we want to be able to cross-reference an EMPIAR accessions in the same way as BioImageArchive/BioStudies.

This change to the study parser allows to recognize `Study EMPIAR Accession` as a new valid key in the study file and will create a new `EMPIAR Accession` key with  `EMPIAR-<id> https://www.ebi.ac.uk/pdbe/emdb/empiar/entry/<id>` as a value in the study map.

/cc @francesw @dominikl likely to be tested in the context of `idr0083`