### PR TITLE
Improve DOI parsing in study file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 ---
+os: linux
+dist: xenial
 language: python
-sudo: false
-
+python: "3.6"
 cache: pip
 
 install: pip install .
 
 before_script: flake8 -v .
 
-script: python test/all_tests.py
+script: pytest

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -83,7 +83,7 @@ KEYS = (
     Key('Screen Technology Type', 'Screen', optional=True),
 )
 
-DOI_PATTERN = re.compile("https?://(dx.)?doi.org/(?P<id>.*)")
+DOI_PATTERN = re.compile(r"https?://(dx.)?doi.org/(?P<id>\b10\.\d+/\S+\b)")
 STUDY_NS = "idr.openmicroscopy.org/study/info"
 COMPONENTS_NS = "idr.openmicroscopy.org/study/components"
 

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -251,7 +251,8 @@ class StudyParser(object):
 
         self.study["Publications"] = publications
 
-    def parse_data_doi(self, d, key):
+    @staticmethod
+    def parse_data_doi(d, key):
         if key not in d:
             return {}
         m = DOI_PATTERN.match(d[key])

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -83,7 +83,8 @@ KEYS = (
     Key('Screen Technology Type', 'Screen', optional=True),
 )
 
-DOI_PATTERN = re.compile(r"https?://(dx.)?doi.org/(?P<id>\b10\.\d+/\S+\b)")
+DOI_PATTERN = re.compile(
+    r"(?P<url>https?://(dx.)?doi.org/)?(?P<id>\b10\.\d+/\S+\b)")
 STUDY_NS = "idr.openmicroscopy.org/study/info"
 COMPONENTS_NS = "idr.openmicroscopy.org/study/components"
 

--- a/test/test_study_parser.py
+++ b/test/test_study_parser.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+from pyidr.study_parser import StudyParser
+import pytest
+
+
+class TestDOI(object):
+
+    def test_missing_key(self):
+        assert StudyParser.parse_data_doi({}, 'Study DOI') == {}
+
+    @pytest.mark.parametrize('doi', (
+        'https://doi.org/10.17867/10000134',
+        'https://dx.doi.org/10.17867/10000134',
+        'http://doi.org/10.17867/10000134',
+        'http://dx.doi.org/10.17867/10000134'))
+    def test_valid_doi_link(self, doi):
+        d = {'Study DOI': doi}
+        assert StudyParser.parse_data_doi(d, 'Study DOI') == {
+            'Data DOI': '10.17867/10000134'}
+
+    def test_invalid_doi_link(self):
+        d = {'Study DOI': 'doi.org/10.17867/10000134'}
+        with pytest.raises(Exception):
+            StudyParser.parse_data_doi(d, 'Study DOI')
+
+    def test_doi_name(self):
+        d = {'Study DOI': '10.17867/10000134'}
+        with pytest.raises(Exception):
+            StudyParser.parse_data_doi(d, 'Study DOI')

--- a/test/test_study_parser.py
+++ b/test/test_study_parser.py
@@ -21,7 +21,7 @@ class TestDOI(object):
         'https://dx.doi.org/10.17867/10000134',
         'http://doi.org/10.17867/10000134',
         'http://dx.doi.org/10.17867/10000134'))
-    def test_valid_doi_link(self, doi):
+    def test_doi_url_prefixes(self, doi):
         d = {'Study DOI': doi}
         assert StudyParser.parse_data_doi(d, 'Study DOI') == {
             'Data DOI': '10.17867/10000134'}
@@ -32,12 +32,13 @@ class TestDOI(object):
             StudyParser.parse_data_doi(d, 'Study DOI')
 
     @pytest.mark.parametrize('doi', VALID_DOIS)
-    def test_valid_dois(self, doi):
+    def test_valid_doi_names(self, doi):
         d = {'Study DOI': 'https://doi.org/%s' % doi}
         assert StudyParser.parse_data_doi(d, 'Study DOI') == {
             'Data DOI': doi}
 
-    def test_doi_name(self):
-        d = {'Study DOI': '10.17867/10000134'}
-        with pytest.raises(Exception):
-            StudyParser.parse_data_doi(d, 'Study DOI')
+    @pytest.mark.parametrize('doi', VALID_DOIS)
+    def test_valid_doi_urls(self, doi):
+        d = {'Study DOI': doi}
+        assert StudyParser.parse_data_doi(d, 'Study DOI') == {
+            'Data DOI': doi}

--- a/test/test_study_parser.py
+++ b/test/test_study_parser.py
@@ -6,6 +6,13 @@ import pytest
 
 class TestDOI(object):
 
+    VALID_DOIS = [
+      '10.1083/jcb.20110809',
+      '10.1016/j.cell.2008.12.041',
+      '10.17867/10000108',
+      '10.1093/gigascience/giw014'
+    ]
+
     def test_missing_key(self):
         assert StudyParser.parse_data_doi({}, 'Study DOI') == {}
 
@@ -23,6 +30,12 @@ class TestDOI(object):
         d = {'Study DOI': 'doi.org/10.17867/10000134'}
         with pytest.raises(Exception):
             StudyParser.parse_data_doi(d, 'Study DOI')
+
+    @pytest.mark.parametrize('doi', VALID_DOIS)
+    def test_valid_dois(self, doi):
+        d = {'Study DOI': 'https://doi.org/%s' % doi}
+        assert StudyParser.parse_data_doi(d, 'Study DOI') == {
+            'Data DOI': doi}
 
     def test_doi_name(self):
         d = {'Study DOI': '10.17867/10000134'}


### PR DESCRIPTION
Minor cleanups while reviewing the publications associated with IDR datasets:

- add support for DOIs either under the `prefix/suffix` form e.g `10.17867/10000134` or the URL form e.g. https://doi.org/10.17867/10000134 in the study file
- improve the strictness of the DOI prefix/suffix regex parsing
- add unit tests for the DOI parsing and use `pytest`