### PR TITLE
Fix stats generation script

### DIFF
--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -71,12 +71,12 @@ def studies():
 
         logging.info("Finding containers for study %s" % study)
         target = "Plate"
-        containers = glob(join(study, "screen[ABC]"))
+        containers = glob(join(study, "screen[A-Z]"))
         if containers:
             assert not glob(join(study, "experiment*")), study
         else:
             target = "Dataset"
-            containers = glob(join(study, "experiment*"))
+            containers = glob(join(study, "experiment[A-Z]"))
 
         assert len(containers) >= 1
         for container in sorted(containers):

--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -102,7 +102,7 @@ def studies():
                 with input(files=[p], openhook=hook_compressed) as f:
                     for line in f:
                         if isinstance(line, bytes):  # compressed files
-                            line.decode()
+                            line = line.decode('utf-8')
                         parts = line.strip().split("\t")
                         if name_idx:
                             name = parts[name_idx]

--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -11,6 +11,7 @@ from os.path import dirname
 from os.path import exists
 from os.path import join
 from sys import stderr
+import logging
 
 
 from omero import all  # noqa
@@ -68,6 +69,7 @@ def studies():
         if "idr0000-" in study or "idr-utils" in study:
             continue
 
+        logging.info("Finding containers for study %s" % study)
         target = "Plate"
         containers = glob(join(study, "screen[ABC]"))
         if containers:
@@ -191,6 +193,7 @@ def stat_screens(query):
 
     for study, containers in sorted(studies().items()):
         for container, set_expected in sorted(containers.items()):
+            logging.info("Retrieving stats for %s" % container)
             params = ParametersI()
             params.addString("container", container)
             if "Plate" in set_expected:
@@ -310,7 +313,13 @@ def main():
     parser.add_argument("--copy-type", default="Image")
     parser.add_argument("--copy-to", type=int, default=None)
     parser.add_argument("screen", nargs="?")
+    parser.add_argument('-v', '--verbose', action='count', default=0)
     ns = parser.parse_args()
+
+    levels = [logging.WARNING, logging.INFO, logging.DEBUG]
+    level = levels[min(len(levels)-1, ns.verbose)]
+    logging.basicConfig(
+        level=level, format="%(asctime)s %(levelname)s %(message)s")
 
     cli = CLI()
     cli.loadplugins()

--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -101,6 +101,8 @@ def studies():
                     p = "%s.gz" % p
                 with input(files=[p], openhook=hook_compressed) as f:
                     for line in f:
+                        if isinstance(line, bytes):  # compressed files
+                            line.decode()
                         parts = line.strip().split("\t")
                         if name_idx:
                             name = parts[name_idx]

--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -76,7 +76,7 @@ def studies():
             target = "Dataset"
             containers = glob(join(study, "experiment*"))
 
-        assert containers >= 1
+        assert len(containers) >= 1
         for container in sorted(containers):
             bulks = glob(join(container, "*-bulk.yml"))
             bulks += glob(join(container, "**/*-bulk.yml"))

--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -65,7 +65,7 @@ def studies():
     for study in sorted(glob("idr*")):
         if study[-1] == "/":
             study = study[0:-1]
-        if "idr0000-" in study:
+        if "idr0000-" in study or "idr-utils" in study:
             continue
 
         target = "Plate"

--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -99,18 +99,19 @@ def studies():
 
                 if not exists(p) and exists("%s.gz" % p):
                     p = "%s.gz" % p
-                for line in eval(input([p], openhook=hook_compressed)):
-                    parts = line.strip().split("\t")
-                    if name_idx:
-                        name = parts[name_idx]
-                    else:
-                        if path_idx < len(parts):
-                            name = basename(parts[path_idx])
+                with fileinput.input(files=[p], openhook=hook_compressed) as f:
+                    for line in f:
+                        parts = line.strip().split("\t")
+                        if name_idx:
+                            name = parts[name_idx]
                         else:
-                            raise Exception(path_idx, container, bulk)
-                    if target_idx:
-                        target = parts[target_idx]
-                    rv[study][container][target].append(name)
+                            if path_idx < len(parts):
+                                name = basename(parts[path_idx])
+                            else:
+                                raise Exception(path_idx, container, bulk)
+                        if target_idx:
+                            target = parts[target_idx]
+                        rv[study][container][target].append(name)
 
     for study, containers in sorted(rv.items()):
         for container, types in sorted(containers.items()):

--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -99,7 +99,7 @@ def studies():
 
                 if not exists(p) and exists("%s.gz" % p):
                     p = "%s.gz" % p
-                with fileinput.input(files=[p], openhook=hook_compressed) as f:
+                with input(files=[p], openhook=hook_compressed) as f:
                     for line in f:
                         parts = line.strip().split("\t")
                         if name_idx:


### PR DESCRIPTION
As reported by @dominikl, this PR amends the `stats.py` generation script to match a few architectural changes since `prod80`:

- fix the script followin the Python2 -> Python 3 upgrade (`len`, `fileinput`)
- handle the migration of the utility scripts under `idr-utils`
- add logging to the scripts

These changes can be tested against the live IDR from a checkout of https://github.com/IDR/idr-metadata and a Python 3 virtual environment with OMERO.py installed.

```
cd /uod/idr/metadata
source ~/venvs/omeropy/bin/activate
python idr-utils/scripts/stats.py
```
