### PR TITLE
Add support for the external URL in the study annotation in the resource

### DIFF
--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -315,6 +315,7 @@ class Formatter(object):
         ('Data Publisher', "%(Study Data Publisher)s"),
         ('Data DOI', "%(Data DOI)s "
          "https://doi.org/%(Data DOI)s"),
+        ('External URL', "%(Study External URL)s"),
         ('BioStudies Accession', "%(Study BioImage Archive Accession)s"
          " https://www.ebi.ac.uk/biostudies/studies/"
          "%(Study BioImage Archive Accession)s"),


### PR DESCRIPTION
Many studies include a reference to an external URL, usually the homepage of the project but this information is lost in the live resource.

This change should transform each tab-separated value in the study file as a key/value pair in the top-level study annotation