### PR TITLE
Uncap pandas version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     install_requires=[
         "future",
         "PyYAML",
-        "pandas<0.19",
+        "pandas",
         "flake8",
         "yamllint"
     ]


### PR DESCRIPTION
https://travis-ci.org/github/IDR/idr-metadata/builds/712093394 highlights some incompatibilities

```
Traceback (most recent call last):
  File "idr-utils/scripts/travis-check.py", line 11, in <module>
    import pandas
  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/pandas/__init__.py", line 56, in <module>
    from pandas.util.nosetester import NoseTester
  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/pandas/util/nosetester.py", line 13, in <module>
    from numpy.testing import nosetester
ImportError: cannot import name 'nosetester'
```

With the migration to PYthon3, we should be able to consume the stable `1.x` version of pandas