### PR TITLE
Cleanup stats.py before more refactoring

### DIFF
--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -180,7 +180,7 @@ def check_search(query, search):
                 continue
 
 
-def stat_screens(query):
+def stat_top_level(query):
 
     tb = TableBuilder("Container")
     tb.cols(["ID", "Set", "Wells", "Images", "Planes", "Bytes"])
@@ -325,7 +325,7 @@ def main():
             search = client.sf.createSearchService()
             check_search(query, search)
         elif not ns.screen:
-            stat_screens(query)
+            stat_top_level(query)
         else:
             for x in stat_plates(query, ns.screen, ns.images):
                 print(x)

--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -296,12 +296,6 @@ def stat_plates(query, screen, images=False):
     print(str(tb.build()))
 
 
-def copy(client, copy_from, copy_type, copy_to):
-    gateway = BlitzGateway(client_obj=client)
-    print(gateway.applySettingsToSet(copy_from, copy_type, [copy_to]))
-    gateway.getObject("Image", copy_to).getThumbnail(size=(96,), direct=False)
-
-
 def main():
     parser = Parser()
     parser.add_login_arguments()
@@ -309,9 +303,6 @@ def main():
     parser.add_argument("--unknown", action="store_true")
     parser.add_argument("--search", action="store_true")
     parser.add_argument("--images", action="store_true")
-    parser.add_argument("--copy-from", type=int, default=None)
-    parser.add_argument("--copy-type", default="Image")
-    parser.add_argument("--copy-to", type=int, default=None)
     parser.add_argument("screen", nargs="?")
     parser.add_argument('-v', '--verbose', action='count', default=0)
     ns = parser.parse_args()
@@ -336,11 +327,8 @@ def main():
         elif not ns.screen:
             stat_screens(query)
         else:
-            if ns.copy_to:
-                copy(client, ns.copy_from, ns.copy_type, ns.copy_to)
-            else:
-                for x in stat_plates(query, ns.screen, ns.images):
-                    print(x)
+            for x in stat_plates(query, ns.screen, ns.images):
+                print(x)
     finally:
         cli.close()
 

--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -24,7 +24,7 @@ from omero.sys import ParametersI  # noqa
 from omero.util.text import TableBuilder  # noqa
 from omero.util.text import filesizeformat  # noqa
 
-from yaml import load
+from yaml import safe_load
 
 PDI_QUERY = (
     "select p.id, count(distinct d.id), "
@@ -60,7 +60,7 @@ SPW_QUERY = (
 
 def studies():
     with open("bulk.yml") as f:
-        default_columns = load(f).get("columns", {})
+        default_columns = safe_load(f).get("columns", {})
 
     rv = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
     for study in sorted(glob("idr*")):
@@ -85,7 +85,7 @@ def studies():
             for bulk in bulks:
                 pdir = dirname(bulk)
                 with open(bulk, "r") as f:
-                    y = load(f)
+                    y = safe_load(f)
                 p = join(pdir, y["path"])
                 columns = y.get("columns", default_columns)
                 name_idx = None


### PR DESCRIPTION
- Remove the screen rendering option (replaced by the render CLI plugin)
- Rename the `stat_screens` method since it's for all top-level containers.
- Use `yaml.safe_load` to avoid a deprecation warning
- Remove the `screen` argument and corresponding `stat_plates` method since it doesn't seem to work, it always returns 0
```
    $ ./idr-utils/scripts/stats.py idr0001-graml-sysgro/screenA
    Using session for public@idr.openmicroscopy.org:4064. Idle timeout: 10 min. Current group: Public
     Plate | PID | Wells | Images
    -------+-----+-------+--------
     Total |     | 0     | 0
    (1 row)

    $ ./idr-utils/scripts/stats.py  idr0002-heriche-condensation/screenA
    Using session for public@idr.openmicroscopy.org:4064. Idle timeout: 10 min. Current group: Public
     Plate | PID | Wells | Images
    -------+-----+-------+--------
     Total |     | 0     | 0
    (1 row)

    $ ./idr-utils/scripts/stats.py  idr0008-rohn-actinome/screenB
    Using session for public@idr.openmicroscopy.org:4064. Idle timeout: 10 min. Current group: Public
     Plate | PID | Wells | Images
    -------+-----+-------+--------
     Total |     | 0     | 0
    (1 row)
```
- A subset of studies can be passed on the command line if you don't want to calculate stats for all studies, e.g.
```
$ ./idr-utils/scripts/stats.py idr0070-kerwin-hdbr idr0081-georgi-adenovirus
Using session for public@idr.openmicroscopy.org:4064. Idle timeout: 10 min. Current group: Public
 Container                         | ID   | Set         | Wells | Images | Planes | Bytes
-----------------------------------+------+-------------+-------+--------+--------+---------
 idr0070-kerwin-hdbr/experimentA   | 1104 | 287 of 2362 | 0     | 4554   | 13512  | 4.9 TB
 idr0081-georgi-adenovirus/screenA | 2401 | 2           | 768   | 768    | 1536   | 12.0 GB
 idr0081-georgi-adenovirus/screenB | 2402 | 2           | 768   | 768    | 1536   | 12.0 GB
 idr0081-georgi-adenovirus/screenC | 2403 | 2           | 768   | 768    | 1536   | 12.0 GB
 idr0081-georgi-adenovirus/screenD | 2404 | 16          | 6144  | 6144   | 12288  | 96.0 GB
 idr0081-georgi-adenovirus/screenE | 2405 | 16          | 6144  | 6144   | 12288  | 96.0 GB
 Total                             |      | 325         | 14592 | 19146  | 42696  | 5.2 TB
(7 rows)
```