### PR TITLE
Refactor stats.py

### DIFF
--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -352,7 +352,7 @@ def stat_top_level(client, study_list, *, release, fsusage, append_totals):
                         fs_size = bytes
                         fs_num = None
                     if fs_num:
-                        fs_avg_size = fs_size / fs_num
+                        fs_avg_size = fs_size / fs_num / (10 ** 6)
                     else:
                         fs_avg_size = None
                     df.loc[len(df)] = (
@@ -370,7 +370,7 @@ def stat_top_level(client, study_list, *, release, fsusage, append_totals):
                         fs_size / (10 ** 12),
                         fs_size,
                         fs_num,
-                        fs_avg_size / (10 ** 6),
+                        fs_avg_size,
                         avg_image_dim,
                     )
 

--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -339,10 +339,12 @@ def stat_top_level(client, study_list, *, fsusage, append_totals):
                     if fsusage:
                         fs_size, fs_num = fs_usage(
                             client, parenttype, plate_id)
-                        fs_avg_size = fs_size / fs_num
                     else:
                         fs_size = bytes
                         fs_num = None
+                    if fs_num:
+                        fs_avg_size = fs_size / fs_num
+                    else:
                         fs_avg_size = None
                     df.loc[len(df)] = (
                         container1,

--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -186,23 +186,33 @@ def stat_top_level(query, study_list, printfmt='string'):
     df = pd.DataFrame(columns=(
         "Study",
         "Container",
-        # "Introduced",
+        "Introduced",
         "ID",  # "Internal ID"
         "Set",
         "Wells",
-        # "Experiments
+        "Experiments",
         #    (wells for screens, imaging experiments for non-screens)",
-        # "Targets (genes, small molecules, geographic locations, or
-        #    combination of factors (idr0019, 26, 34, 38)",
-        # "Acquisitions",
+        "Targets",
+        #    (genes, small molecules, geographic locations, or combination of
+        #    factors (idr0019, 26, 34, 38)",
+        "Acquisitions",
         "Images",  # "5D Images"
         "Planes",
-        # "Size (TB)",
+        "Size (TB)",
         "Bytes",  # "Size"
-        # "# of Files",
-        # "avg. size (MB)",
-        # "Avg. Image Dim (XYZCT)",
+        "# of Files",
+        "avg. size (MB)",
+        "Avg. Image Dim (XYZCT)",
     ))
+
+    # Placeholders:
+    introduced = ""
+    experiments = None
+    targets = None
+    acquisitions = None
+    files = None
+    avg_size = None
+    avn_image_dim = None
 
     for study, containers in sorted(studies(study_list).items()):
         for container, set_expected in sorted(containers.items()):
@@ -224,12 +234,21 @@ def stat_top_level(query, study_list, printfmt='string'):
                 df.loc[len(df)] = (
                     container1,
                     container2,
+                    introduced,
                     "MISSING",
                     0,
                     0,
+                    experiments,
+                    targets,
+                    acquisitions,
                     0,
                     0,
-                    0)
+                    0,
+                    0,
+                    files,
+                    avg_size,
+                    avn_image_dim,
+                )
             else:
                 for x in rv:
                     plate_id, plates, wells, images, planes, bytes = x
@@ -244,16 +263,24 @@ def stat_top_level(query, study_list, printfmt='string'):
                     df.loc[len(df)] = (
                         container1,
                         container2,
+                        introduced,
                         plate_id,
                         nexpected,
                         wells,
+                        experiments,
+                        targets,
+                        acquisitions,
                         images,
                         planes,
+                        bytes / 2 ** 40,
                         bytes,
+                        files,
+                        avg_size,
+                        avn_image_dim,
                     )
 
-    totals = df.iloc[:, -5:].sum()
-    df.loc[len(df)] = ["Total", "", ""] + totals.to_list()
+    totals = df.iloc[:, -12:-2].sum()
+    df.loc[len(df)] = ["Total", "", "", ""] + totals.to_list() + ["", ""]
 
     with pd.option_context(
             'display.max_rows', None, 'display.max_columns', None):

--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -364,10 +364,10 @@ def stat_top_level(client, study_list, *, fsusage, append_totals):
                         acquisitions,
                         images,
                         planes,
-                        fs_size / 2 ** 40,
+                        fs_size / (10 ** 12),
                         fs_size,
                         fs_num,
-                        fs_avg_size,
+                        fs_avg_size / (10 ** 6),
                         avg_image_dim,
                     )
 

--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -246,9 +246,10 @@ def fs_usage(client, objecttype, objectid):
     return sizebytes, nfiles
 
 
-def stat_top_level(client, study_list, *, fsusage, append_totals):
+def stat_top_level(client, study_list, *, release, fsusage, append_totals):
     # Calculate stats for the studies.tsv file.
     # client: OMERO client
+    # release: THe name of the IDR release
     # study_list: List of studies
     # fsusage: If True use the OMERO DiskUsage2 command to get information
     #   on disk usage, otherwise make a rough guess and ignore other fields
@@ -281,7 +282,6 @@ def stat_top_level(client, study_list, *, fsusage, append_totals):
     ))
 
     # Placeholders:
-    introduced = ""
     experiments = None
     targets = None
     acquisitions = None
@@ -308,7 +308,7 @@ def stat_top_level(client, study_list, *, fsusage, append_totals):
                 df.loc[len(df)] = (
                     container1,
                     container2,
-                    introduced,
+                    release,
                     "MISSING",
                     0,
                     0,
@@ -355,7 +355,7 @@ def stat_top_level(client, study_list, *, fsusage, append_totals):
                     df.loc[len(df)] = (
                         container1,
                         container2,
-                        introduced,
+                        release,
                         plate_or_dataset_id,
                         nexpected,
                         wells,
@@ -396,12 +396,14 @@ def main():
     parser.add_argument("--unknown", action="store_true")
     parser.add_argument("--search", action="store_true")
     parser.add_argument("--images", action="store_true")
+    parser.add_argument("--release", default="TODO",
+                        help="The name of the release, e.g. 'prod88'")
     parser.add_argument("--disable-fsusage", action="store_true", help=(
         "Disable fs usage file size and counts. "
         "Use this flag if the script is taking too long."))
     parser.add_argument("--format", default="tsv", help=(
         "Output format, includes 'string', 'csv', 'tsv' (default), and "
-        "others. "
+        "'json'. "
         "'tsv' can be appended to the IDR studies.csv file with no further "
         "processing. "
         "All other formats include headers and totals. "
@@ -433,6 +435,7 @@ def main():
         else:
             df = stat_top_level(
                 client, ns.studies,
+                release=ns.release,
                 fsusage=(not ns.disable_fsusage),
                 append_totals=(ns.format != 'tsv'))
             print_stats(df, ns.format)

--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -261,7 +261,7 @@ def stat_top_level(client, study_list, *, fsusage, append_totals):
         "Container",
         "Introduced",
         "ID",  # "Internal ID"
-        "Set",
+        "Set",  # Number of plates or datasets
         "Wells",
         "Experiments",
         #    (wells for screens, imaging experiments for non-screens)",
@@ -325,19 +325,26 @@ def stat_top_level(client, study_list, *, fsusage, append_totals):
                 )
             else:
                 for x in rv:
-                    (plate_id, plates, wells, images, planes, bytes,
-                        avg_image_dim) = x
+                    (
+                        plate_or_dataset_id,
+                        plate_or_datasets,
+                        wells,
+                        images,
+                        planes,
+                        bytes,
+                        avg_image_dim
+                    ) = x
                     if not planes:
                         planes = 0
                     if not bytes:
                         bytes = 0
-                    if plates != nexpected:
+                    if plate_or_datasets != nexpected:
                         logging.warning(
-                            '%s: got %d plates expected %d',
-                            container, plates, nexpected)
+                            '%s: got %d plate/datasets expected %d',
+                            container, plate_or_datasets, nexpected)
                     if fsusage:
                         fs_size, fs_num = fs_usage(
-                            client, parenttype, plate_id)
+                            client, parenttype, plate_or_dataset_id)
                     else:
                         fs_size = bytes
                         fs_num = None
@@ -349,7 +356,7 @@ def stat_top_level(client, study_list, *, fsusage, append_totals):
                         container1,
                         container2,
                         introduced,
-                        plate_id,
+                        plate_or_dataset_id,
                         nexpected,
                         wells,
                         experiments,

--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -215,7 +215,6 @@ def check_search(query, search):
 def fs_usage(client, objecttype, objectid):
     req = DiskUsage2()
     req.targetObjects = {objecttype: [objectid]}
-    req.targetClasses = [objecttype]
 
     cb = None
     handle = None

--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -31,6 +31,7 @@ PDI_QUERY = """
         p.id,
         COUNT(DISTINCT d.id),
         0,
+        0,
         COUNT(DISTINCT i.id),
         SUM(CAST(pix.sizeZ AS long) * pix.sizeT * pix.sizeC),
         SUM(CAST(pix.sizeZ AS long) * pix.sizeT * pix.sizeC *
@@ -61,6 +62,7 @@ SPW_QUERY = """
         s.id,
         COUNT(DISTINCT p.id),
         COUNT(DISTINCT w.id),
+        COUNT(DISTINCT pa.id),
         COUNT(DISTINCT i.id),
         SUM(CAST(pix.sizeZ AS long) * pix.sizeT * pix.sizeC),
         SUM(CAST(pix.sizeZ AS long) * pix.sizeT * pix.sizeC *
@@ -81,6 +83,7 @@ SPW_QUERY = """
     LEFT OUTER JOIN spl.child p
     LEFT OUTER JOIN p.wells w
     LEFT OUTER JOIN w.wellSamples ws
+    LEFT OUTER JOIN ws.plateAcquisition pa
     LEFT OUTER JOIN ws.image i
     LEFT OUTER JOIN i.pixels pix
     WHERE s.name = :container
@@ -274,17 +277,16 @@ def stat_top_level(client, study_list, *, release, fsusage, append_totals):
         "Acquisitions",
         "Images",  # "5D Images"
         "Planes",
-        "Size (TB)",  # TODO: from fs usage
-        "Bytes",  # "Size"  # TODO: from fs usage
-        "# of Files",  # TODO: from fs usage
-        "avg. size (MB)",  # TODO: from fs usage
+        "Size (TB)",
+        "Bytes",  # "Size"
+        "# of Files",
+        "avg. size (MB)",
         "Avg. Image Dim (XYZCT)",
     ))
 
     # Placeholders:
     experiments = None
     targets = None
-    acquisitions = None
 
     for study, containers in sorted(studies(study_list).items()):
         for container, set_expected in sorted(containers.items()):
@@ -314,7 +316,7 @@ def stat_top_level(client, study_list, *, release, fsusage, append_totals):
                     0,
                     experiments,
                     targets,
-                    acquisitions,
+                    0,
                     0,
                     0,
                     0,
@@ -329,6 +331,7 @@ def stat_top_level(client, study_list, *, release, fsusage, append_totals):
                         plate_or_dataset_id,
                         plate_or_datasets,
                         wells,
+                        acquisitions,
                         images,
                         planes,
                         bytes,

--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -233,11 +233,11 @@ def fs_usage(client, objecttype, objectid):
     except KeyboardInterrupt:
         # If user uses Ctrl-C, then cancel
         if handle is not None:
-            logging.warn("Attempting cancel...")
+            logging.warning("Attempting cancel...")
             if handle.cancel():
-                logging.warn("Cancelled")
+                logging.warning("Cancelled")
             else:
-                logging.warn("Failed to cancel")
+                logging.warning("Failed to cancel")
     finally:
         if cb is not None:
             cb.close(True)  # Close handle
@@ -396,8 +396,9 @@ def main():
         "others. "
         "'tsv' can be appended to the IDR studies.csv file with no further "
         "processing. "
+        "All other formats include headers and totals. "
         "'string' is the most human readable (fixed width columns). "
-        "All other formats include headers and totals."))
+    ))
     parser.add_argument(
         "studies", nargs='*',
         help="Studies to be processed, default all (idr*)")

--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -183,35 +183,25 @@ def check_search(query, search):
 def stat_top_level(query, study_list, printfmt='string'):
     # printfmt can be any of the pandas.Dataframe.to_{printfmt} methods
 
-    # df = pd.DataFrame(columns=(
-    #     "Study",
-    #     "Container",
-    #     "Introduced",
-    #     "Internal ID",
-    #     "Sets",
-    #     "Wells",
-    #     "Experiments
-    #        (wells for screens, imaging experiments for non-screens)",
-    #     "Targets (genes, small molecules, geographic locations, or
-    #        combination of factors (idr0019, 26, 34, 38)",
-    #     "Acquisitions",
-    #     "5D Images",
-    #     "Planes",
-    #     "Size (TB)",
-    #     "Size",
-    #     "# of Files",
-    #     "avg. size (MB)",
-    #     "Avg. Image Dim (XYZCT)",
-    # ))
     df = pd.DataFrame(columns=(
         "Study",
         "Container",
-        "ID",
+        # "Introduced",
+        "ID",  # "Internal ID"
         "Set",
         "Wells",
-        "Images",
+        # "Experiments
+        #    (wells for screens, imaging experiments for non-screens)",
+        # "Targets (genes, small molecules, geographic locations, or
+        #    combination of factors (idr0019, 26, 34, 38)",
+        # "Acquisitions",
+        "Images",  # "5D Images"
         "Planes",
-        "Bytes",
+        # "Size (TB)",
+        "Bytes",  # "Size"
+        # "# of Files",
+        # "avg. size (MB)",
+        # "Avg. Image Dim (XYZCT)",
     ))
 
     for study, containers in sorted(studies(study_list).items()):


### PR DESCRIPTION
`stats.py` now defaults to printing out something that can be appended to [`studies.tsv`](https://github.com/IDR/idr.openmicroscopy.org/blob/master/_data/studies.tsv), e.g.:

```
omero login
./idr-utils/scripts/stats.py idr0048-abdeladim-chroms >> studies.tsv
```
This includes the fs usage calculation which may take a very long time or may crash the server. To disable the fs usage calculation:
```
./idr-utils/scripts/stats.py --disable-fsusage idr0048-abdeladim-chroms >> studies.tsv
```
If you want a human readable output pass `--format string` (`string` refers to a pandas output format).