### PR TITLE
stats.py: fix calculation of Sets

### DIFF
--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -342,10 +342,11 @@ def stat_top_level(client, study_list, *, release, fsusage, append_totals):
                     if not bytes:
                         bytes = 0
                     if plate_or_datasets != nexpected:
-                        logging.warning(
+                        logging.debug(
                             '%s: got %d plate/datasets expected %d',
                             container, plate_or_datasets, nexpected)
                     if fsusage:
+                        logging.debug('Computing disk usage')
                         fs_size, fs_num = fs_usage(
                             client, parenttype, plate_or_dataset_id)
                     else:
@@ -360,7 +361,7 @@ def stat_top_level(client, study_list, *, release, fsusage, append_totals):
                         container2,
                         release,
                         plate_or_dataset_id,
-                        nexpected,
+                        plate_or_datasets,
                         wells,
                         experiments,
                         targets,


### PR DESCRIPTION
Follow-up of #16, this fixes the calculation of the `Sets` column to use the return of the query. 

Previously, the value of `nexpected` was used which corresponds to the number of rows in the `filePaths.tsv` or `plates.tsv`- see https://github.com/IDR/idr.openmicroscopy.org/pull/93. This PR updates the script to use the query returning the number of datasets in the project or plates in the screen - see https://github.com/IDR/idr.openmicroscopy.org/pull/94/commits/043e3669b6e33022ce0582c4b4d07e6c3a7b57ab.