### PR TITLE
Remove unnecessary check for bulk.yml

### DIFF
--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -91,9 +91,7 @@ SPW_QUERY = """
 """
 
 
-def studies(study_list):
-    with open("bulk.yml") as f:
-        default_columns = safe_load(f).get("columns", {})
+def studies(study_list, default_columns=["name", "path"]):
 
     rv = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
     if not study_list:


### PR DESCRIPTION
This file was only used to return the default columns which should be largely unrelated to the computed stats.