### PR TITLE
Prevent git-restore-mtime-bare.py from setting timestamps on symlinks

### DIFF
--- a/scripts/git-restore-mtime-bare.py
+++ b/scripts/git-restore-mtime-bare.py
@@ -50,7 +50,7 @@ mtime = 0
 gitobj = subprocess.Popen(shlex.split('git whatchanged --pretty=%at'),
                           stdout=subprocess.PIPE)
 for line in gitobj.stdout:
-    line = line.strip()
+    line = line.strip().decode("utf-8")
 
     # Blank line between Date and list of files
     if not line:
@@ -62,7 +62,7 @@ for line in gitobj.stdout:
         if file in filelist:
             filelist.remove(file)
             # print mtime, file
-            os.utime(file, (mtime, mtime))
+            os.utime(file, (mtime, mtime), follow_symlinks=False)
 
     # Date line
     else:

--- a/scripts/git-restore-mtime-bare.py
+++ b/scripts/git-restore-mtime-bare.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Change mtime of files based on commit date of last change
 #
 #    Copyright (C) 2012 Rodrigo Silva (MestreLion) <linux@rodrigosilva.com>


### PR DESCRIPTION
- Use os.utime() follow_symlinks keyword available on Python 3
- Also decode the output of the subprocess as a string on Python 3

The usage of  `follow_symlinks` is primarily motivated by the fact that apart from the top-level `idr0015§ symlinks, all links are pointing to read-only data on NFS and this script results in `Permission Denied`.