### PR TITLE
Check annotation report

### DIFF
--- a/scripts/annotate/check_annotations.py
+++ b/scripts/annotate/check_annotations.py
@@ -27,7 +27,9 @@ parser.add_argument("target", help="Project:123 or Screen:123")
 parser.add_argument("file", nargs="?", help="The annotation.csv file")
 parser.add_argument("-v", "--verbose", action="count", default=0,
                     help="Verbosity (-v, -vv, etc)")
-parser.add_argument("--report", help="File with the validation output")
+parser.add_argument(
+    "-o", "--output",
+    help="A copy of the annotation.csv file including the detected problems")
 
 
 args = parser.parse_args()
@@ -196,6 +198,6 @@ if not problems:
     sys.exit(0)
 else:
     report_problems()
-    if args.report:
-        df.to_csv(args.report, index=False)
+    if args.output:
+        df.to_csv(args.output, index=False)
     sys.exit(1)

--- a/scripts/annotate/check_annotations.py
+++ b/scripts/annotate/check_annotations.py
@@ -129,8 +129,8 @@ if projectId:
     if not project:
         logging.critical("There's no Project with this id.")
         sys.exit(1)
-    for ds in project.listChildren():
-        for img in ds.listChildren():
+    for ds in sorted(project.listChildren(), key=lambda x: x.getName()):
+        for img in sorted(ds.listChildren(), key=lambda x: x.getName()):
             key = "{},{}".format(ds.getName(), img.getName())
             if csv_keys:
                 if key not in csv_keys:
@@ -157,8 +157,8 @@ elif screenId:
     if not screen:
         logging.critical("There's no Screen with this id.")
         sys.exit(1)
-    for pl in screen.listChildren():
-        for well in pl.listChildren():
+    for pl in sorted(screen.listChildren(), key=lambda x: x.getName()):
+        for well in sorted(pl.listChildren(), key=lambda x: x.getWellPos()):
             if well.getWellSample():
                 key = "{},{}".format(pl.getName(), well.getWellPos())
                 if csv_keys:

--- a/scripts/annotate/check_annotations.py
+++ b/scripts/annotate/check_annotations.py
@@ -140,13 +140,13 @@ if projectId:
                         "Errors": "Missing annotation",},
                         ignore_index=True)
                     flag_error(ds.getName(), img.getName(),
-                               "Missing row in CSV")
+                               "Missing annotation in csv file ")
                 else:
                     csv_keys.pop(key)
             else:
                 if not check_annotations(img.listAnnotations()):
                     flag_error(ds.getName(), img.getName(),
-                               "Missing Annotation")
+                               "Missing annotation")
             if key in images:
                 flag_error(ds.getName(), img.getName(),
                            "Non-unique Dataset/Image")
@@ -169,13 +169,13 @@ elif screenId:
                             "Errors": "Missing annotation",},
                             ignore_index=True)
                         flag_error(pl.getName(), well.getWellPos(),
-                                   "Missing row in CSV")
+                                   "Missing annotation in csv file")
                     else:
                         csv_keys.pop(key)
                 else:
                     if not check_annotations(well.listAnnotations()):
                         flag_error(pl.getName(), well.getWellPos(),
-                                   "Missing Annotation")
+                                   "Missing annotation")
                 if key in images:
                     flag_error(pl.getName(), well.getWellPos(),
                                "Non-unique Plate/Well")
@@ -187,9 +187,9 @@ conn.close()
 if csv_keys:
     logging.warning("There are additional entries in the csv file which don't"
                     " match any images:")
-    for key in sorted(csv_keys, key=itemgetter(0, 1)):
+    for key in sorted(csv_keys):
         df.loc[csv_keys[key], "Errors"] = "No image"
-        logging.info("{},No image for this entry".format(key))
+        logging.info("{},No image".format(key))
 
 if not problems:
     print("All images are unique and have annotations.")

--- a/scripts/annotate/check_annotations.py
+++ b/scripts/annotate/check_annotations.py
@@ -137,7 +137,7 @@ if projectId:
                     df = df.append({
                         "Dataset Name": ds.getName(),
                         "Image Name": img.getName(),
-                        "Errors": "Missing annotation",},
+                        "Errors": "Missing annotation"},
                         ignore_index=True)
                     flag_error(ds.getName(), img.getName(),
                                "Missing annotation in csv file ")
@@ -166,7 +166,7 @@ elif screenId:
                         df = df.append({
                             "Plate": pl.getName(),
                             "Well": well.getWellPos(),
-                            "Errors": "Missing annotation",},
+                            "Errors": "Missing annotation"},
                             ignore_index=True)
                         flag_error(pl.getName(), well.getWellPos(),
                                    "Missing annotation in csv file")


### PR DESCRIPTION
Follow-up of #29, this adds an option allowing to produce a CSV file derived from the original passed to the `check_annotations` script with an extra column containing the details of the errors as well as extra rows for the missing annotation lines.

Testing instructions:

- create a project/dataset or a screen/plate well structure e.g.

  ```
  project
    dataset1 
      image1-1.fake 
      image1-2.fake 
      image1-4.fake 
      image1-4.fake 
    dataset2
      image2-1.fake 
      image2-3.fake 
      image2-5.fake 
  ```

-  create an annotation CSV with a mixture of missing rows, extra rows and duplicate rows

  ````csv
  Image Name,Dataset Name,Channel Name
  image1-1.fake,dataset1,DAPI
  image1-2.fake,dataset1,GFP
  image1-1.fake,dataset1,GFP
  image1-3.fake,dataset1,GFP
  image2-1.fake,dataset2,DAPI
  image2-2.fake,dataset2,DAPI
  image2-3.fake,dataset2,,DAPI
  image2-3.fake,dataset2,DAPI
  image2-4.fake,dataset2,DAPI
  ````

- run `python scripts/annotate/check_annotations.py Project:<id> annotation.csv --report out.csv`.

The out.csv file should contain the same data as the original annotation.csv with additional rows and an additional column describing the problematic rows.