### PR TITLE
check_annotations improvements

### DIFF
--- a/scripts/annotate/check_annotations.py
+++ b/scripts/annotate/check_annotations.py
@@ -30,7 +30,8 @@ parser.add_argument("-v", "--verbose", action="count", default=0,
 parser.add_argument(
     "-o", "--output",
     help="A copy of the annotation.csv file including the detected problems")
-
+parser.add_argument("--skip-ok", action="store_true", default=False,
+    help="Don't include entries without problems in the annotation.csv copy")
 
 args = parser.parse_args()
 loglevel = 30 - (args.verbose * 10)
@@ -95,7 +96,7 @@ def check_annotations(anns):
 csv_keys = {}
 
 if args.file:
-    df = pandas.read_csv(args.file)
+    df = pandas.read_csv(args.file, dtype=str)
     # Add reporting column
     df["Errors"] = ""
     if projectId:
@@ -199,5 +200,7 @@ if not problems:
 else:
     report_problems()
     if args.output:
+        if args.skip_ok:
+            df = df[df.Errors != ""]
         df.to_csv(args.output, index=False)
     sys.exit(1)

--- a/scripts/annotate/check_annotations.py
+++ b/scripts/annotate/check_annotations.py
@@ -31,7 +31,8 @@ parser.add_argument(
     "-o", "--output",
     help="A copy of the annotation.csv file including the detected problems")
 parser.add_argument("--skip-ok", action="store_true", default=False,
-    help="Don't include entries without problems in the annotation.csv copy")
+                    help="Don't include entries without problems in the "
+                         "annotation.csv copy")
 
 args = parser.parse_args()
 loglevel = 30 - (args.verbose * 10)
@@ -123,8 +124,8 @@ conn = BlitzGateway(os.environ.get('OMERO_USER', 'public'),
                     host=host, port=port)
 conn.connect()
 
-# Keeps track of all Dataset/Image name resp. Plate/Well pos
-# combinations in the Project/Screen.
+# Keeps track of all Dataset/Image name resp. Plate/Well pos combinations
+# in the Project/Screen.
 images = set()
 
 if projectId:


### PR DESCRIPTION
Just two little improvements to the check_annotations.py script:
- Import the annotations.csv with default `str` data type. Otherwise plate names like '001' will be transformed to '1'.
- Add an option to prevent the entries which don't have any problems from being reported in the output csv. If there are ten thousands of entries and only a few have issues, then the output csv file is very difficult to read.
