### PR TITLE
Idr0097 updates

### DIFF
--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -121,18 +121,17 @@ class StudyParser(object):
         self.log.debug("Expecting %s screen(s) and %s experiment(s)" %
                        (n_screens, n_experiments))
         if n_screens > 0 and n_experiments > 0:
-            type_regexp = '(Screen|Experiment)'
+            component_regexp = '(Screen|Experiment)'
         elif n_screens > 0:
-            type_regexp = '(Screen)'
+            component_regexp = '(Screen)'
         elif n_experiments > 0:
-            type_regexp = '(Experiment)'
+            component_regexp = '(Experiment)'
         else:
             raise Exception("Not enough screens and/or experiments")
 
         # Find all study components in order
         for i in range(n_screens + n_experiments):
-            self.log.debug("Parsing %s %g" % (type_regexp, i + 1))
-            lines, component_type = self.get_lines(i + 1, type_regexp)
+            lines, component_type = self.get_lines(i + 1, component_regexp)
             d = self.parse(component_type, lines=lines)
             d.update({'Type': component_type})
             d.update(self.study)
@@ -176,6 +175,7 @@ class StudyParser(object):
         return d
 
     def get_lines(self, index, component_regexp):
+        self.log.debug("Parsing %s %g" % (component_regexp, i + 1))
         PATTERN = re.compile(r"^%s Number\t(\d+)" % component_regexp)
         found = False
         lines = []
@@ -194,7 +194,7 @@ class StudyParser(object):
                 self._study_lines_used[idx].append(("get_lines", index))
                 lines.append(line)
         if not lines:
-            raise Exception("Could not find %s %g" % (component_type, index))
+            raise Exception("Could not find %s %g" % (component_regexp, index))
         return lines, component_type
 
     def parse_annotation_file(self, component):

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -175,7 +175,7 @@ class StudyParser(object):
         return d
 
     def get_lines(self, index, component_regexp):
-        self.log.debug("Parsing %s %g" % (component_regexp, i + 1))
+        self.log.debug("Parsing %s %g" % (component_regexp, index))
         PATTERN = re.compile(r"^%s Number\t(\d+)" % component_regexp)
         found = False
         lines = []

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -213,11 +213,11 @@ class StudyParser(object):
 
         # Generate GitHub annotation URL
         if os.path.exists(os.path.join(self._dir, ".git")):
-            base_gh_url = "https://github.com/IDR/%s/blob/master/%s" % (
+            base_gh_url = "https://github.com/IDR/%s/blob/HEAD/%s" % (
                 m.group(1), m.group(3))
         else:
             base_gh_url = (
-                "https://github.com/IDR/idr-metadata/blob/master/%s" % name)
+                "https://github.com/IDR/idr-metadata/blob/HEAD/%s" % name)
 
         # Try to find single annotation file in root directory
         for extension in ['.csv', '.csv.gz']:

--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -103,16 +103,15 @@ def studies(study_list, default_columns=["name", "path"]):
             continue
 
         logging.info("Finding containers for study %s" % study)
-        target = "Plate"
-        containers = glob(join(study, "screen[A-Z]"))
-        if containers:
-            assert not glob(join(study, "experiment*")), study
-        else:
-            target = "Dataset"
-            containers = glob(join(study, "experiment[A-Z]"))
+        containers = glob(
+            join(study, "screen[A-Z]")) + glob(join(study, "experiment[A-Z]"))
 
         assert len(containers) >= 1
         for container in sorted(containers):
+            if container.startswith(join(study, "screen")):
+                target = "Plate"
+            else:
+                target = "Dataset"
             bulks = glob(join(container, "*-bulk.yml"))
             bulks += glob(join(container, "**/*-bulk.yml"))
             for bulk in bulks:


### PR DESCRIPTION
The study idr0097 to be released in the upcoming prod9  is the first example of submissions containing a mixture of screens and experiments

A few adjustments are required in the IDR utilities in order to remove the hardcoded assumption that a study is exclusively composed of screens or experiments.

- `study_parser`
    - first read `Study Screens Numbers` and `Study Experiments Numbers` to determine the total number of components and adjust the regexp passed to `get_lines`
    - adjust `get_lines` to return the component type found by the pattern matching
    - not specific to `idr0097`, switch to HEAD for the GitHub URL to handle seamlessly repositories with either `master` or `main` as the default branch
- `stats.py`: find all folders called `screen*` or `experiment*` and determine the type per container