### PR TITLE
Study parser decoding errors

### DIFF
--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -108,7 +108,7 @@ class StudyParser(object):
         self._study_file = study_file
         self._dir = os.path.dirname(self._study_file)
         self.log = logging.getLogger("pyidr.study_parser.StudyParser")
-        with open(self._study_file, 'r') as f:
+        with open(self._study_file, 'r', encoding='utf-8', errors='ignore') as f:
             self.log.info("Parsing %s" % self._study_file)
             self._study_lines = f.readlines()
             self._study_lines_used = [

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -108,7 +108,8 @@ class StudyParser(object):
         self._study_file = study_file
         self._dir = os.path.dirname(self._study_file)
         self.log = logging.getLogger("pyidr.study_parser.StudyParser")
-        with open(self._study_file, 'r', encoding='utf-8', errors='ignore') as f:
+        with open(self._study_file, 'r', encoding='utf-8',
+                  errors='ignore') as f:
             self.log.info("Parsing %s" % self._study_file)
             self._study_lines = f.readlines()
             self._study_lines_used = [


### PR DESCRIPTION
As study files usually are submitted into various encoding, the study parser will regularly fail with encoding errors of type:

```
Traceback (most recent call last):
  File "pyidr/study_parser.py", line 659, in <module>
    parser = main(sys.argv[1:])
  File "pyidr/study_parser.py", line 632, in main
    p = StudyParser(s)
  File "pyidr/study_parser.py", line 113, in __init__
    self._study_lines = f.readlines()
  File "/Users/sbesson/anaconda3/lib/python3.8/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa8 in position 7339: invalid start byte
```

One approach is to unify and force the encoding of study files. This PR explores the alternative approach and makes the study_parser more lenient by forcing an UTF-8 encoding but ignoring errors.

Tested with `idr0072` study file