### PR TITLE
Output to csv even if no errors

### DIFF
--- a/scripts/annotate/check_annotations.py
+++ b/scripts/annotate/check_annotations.py
@@ -195,13 +195,14 @@ if csv_keys:
         df.loc[csv_keys[key], "Errors"] = "No image"
         logging.info("{},No image".format(key))
 
+if args.output:
+    if args.skip_ok:
+        df = df[df.Errors != ""]
+    df.to_csv(args.output, index=False)
+
 if not problems:
     print("All images are unique and have annotations.")
     sys.exit(0)
 else:
     report_problems()
-    if args.output:
-        if args.skip_ok:
-            df = df[df.Errors != ""]
-        df.to_csv(args.output, index=False)
     sys.exit(1)


### PR DESCRIPTION
Little improvement to the check_annotations.py script. Always produce an output if the output option is specified, regardless if there were errors detected. That way you can get a list of annotations which don't match any images ("No Image"), which is not an error.