### PR TITLE
Refactor parsing utility to generate JSON reports of the study files

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -17,6 +17,7 @@ jobs:
           - '3.7'
           - '3.8'
           - '3.9'
+          - '3.10'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -84,7 +84,7 @@ KEYS = (
     Key('Screen Sample Type', 'Screen', multiple=True),
     Key('Screen Imaging Method', 'Screen', multiple=True),
     Key('Screen Number', 'Screen'),
-    Key('Screen Type', 'Screen', multiple=True),
+    Key('Screen Type', 'Screen', optional=True, multiple=True),
     # OPTIONAL_KEYS["Screen"]
     Key('Screen Data DOI', 'Screen', optional=True),
     Key('Screen Data Publisher', 'Screen', optional=True),
@@ -485,7 +485,6 @@ class OMEROFormatter(object):
         authorlists = self.study['Study Author List']
         pubmeds = self.study.get('Study PubMed ID', [])
         pmcs = self.study.get('Study PMC ID', [])
-        print(pmcs)
         dois = self.study.get('Study DOI', [])
         if titles == [''] and authorlists == ['']:
             return []

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -109,7 +109,7 @@ def validate_doi(doi):
     if doi is None:
         return
     m = DOI_PATTERN.match(doi)
-    if not DOI_PATTERN.match(doi):
+    if not m:
         raise Exception(
             "Invalid Data DOI: %s" % doi)
     return m.group("id")
@@ -486,12 +486,12 @@ class OMEROFormatter(object):
     def get_publications(self):
 
         publications = []
-        titles = self.study['Study Publication Title']
-        authorlists = self.study['Study Author List']
+        titles = self.study.get("Study Publication Title", [])
+        authorlists = self.study.get("Study Author List", [])
         pubmeds = self.study.get('Study PubMed ID', [])
         pmcs = self.study.get('Study PMC ID', [])
         dois = self.study.get('Study DOI', [])
-        if titles == [''] and authorlists == ['']:
+        if titles == [] and authorlists == []:
             return []
 
         for it in itertools.zip_longest(

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -260,6 +260,9 @@ class StudyParser(object):
             name = component.get(r"Comment\[IDR %s Name\]" % t, None)
             if name is None:
                 raise Exception("Missing %s name" % t)
+            if not name.startswith(self.study["Study Accession"]):
+                raise Exception("%s does not start with %s" % (
+                    name, self.study["Study Accession"]))
             if study_name is None:
                 study_name = name.split("/")[0]
             else:
@@ -388,8 +391,9 @@ class OMEROFormatter(object):
             if "%s Organism" % component["Type"] not in component:
                 organism_key = "%s Organism" % component["Type"]
                 component[organism_key] = component["Study Organism"]
+            name = component["%s Name" % component["Type"]]
             d = {
-              "name": component["%s Name" % component["Type"]],
+              "name": name,
               "description": self.generate_description(component),
               "map": self.generate_annotation(component),
             }

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -656,7 +656,7 @@ class OMEROFormatter(object):
                      "%s?show=screen-%s" % (WEBCLIENT_URL, screen.id)))
 
         if not found_toplevel:
-            self.log.error(f'Top level container {self.m["name"]} not found')
+            self.log.warning(f'Top level container {self.m["name"]} not found')
 
         for obj in objects:
             self.check_annotation(

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -701,9 +701,10 @@ def main(argv):
                         help="Fail if unknown keys are detected")
     parser.add_argument("--inspect", action="store_true",
                         help="Inspect the internals of the study directory")
-    parser.add_argument("--report",
-                        help="Create a report of the generated objects",
-                        nargs="?", type=str, const='-')
+    parser.add_argument("--report", action="store_true",
+                        help="Create a JSON report of the generated objects")
+    parser.add_argument("--report-directory", type=str,
+                        help="Directory to store the JSON reports")
     parser.add_argument(
         '--verbose', '-v', action='count', default=0,
         help='Increase the command verbosity')
@@ -741,8 +742,15 @@ def main(argv):
 
         if args.report:
             d = JSONFormatter(p, inspect=args.inspect)
-            with open("%s.json" % p.study["Study Accession"], mode="w") as f:
-                f.write(str(d))
+            if args.report_directory:
+                if not os.path.exists(args.report_directory):
+                    os.mkdir(args.report_directory)
+                filepath = "%s/%s.json" % (
+                    args.report_directory, p.study["Study Accession"])
+                with open(filepath, mode="w") as f:
+                    f.write(str(d))
+            else:
+                print(str(d))
 
         if args.check or args.set:
             d = OMEROFormatter(p)

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -701,8 +701,9 @@ def main(argv):
                         help="Fail if unknown keys are detected")
     parser.add_argument("--inspect", action="store_true",
                         help="Inspect the internals of the study directory")
-    parser.add_argument("--report", action="store_true",
-                        help="Create a report of the generated objects")
+    parser.add_argument("--report",
+                        help="Create a report of the generated objects",
+                        nargs="?", type=str, const='-')
     parser.add_argument(
         '--verbose', '-v', action='count', default=0,
         help='Increase the command verbosity')
@@ -740,7 +741,8 @@ def main(argv):
 
         if args.report:
             d = JSONFormatter(p, inspect=args.inspect)
-            print(str(d))
+            with open("%s.json" % p.study["Study Accession"], mode="w") as f:
+                f.write(str(d))
 
         if args.check or args.set:
             d = OMEROFormatter(p)

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -532,7 +532,7 @@ class OMEROFormatter(object):
         publication_titles = [x['Title'] for x in publications]
         study_title = component.get("Study Title", None)
         if study_title is not None and study_title not in publication_titles:
-            add_key_values(component, [('Study Title', "%(Study Title)s")])
+            format_key_values(component, [('Study Title', "%(Study Title)s")])
 
         if component.get("Type", None) == "Experiment":
             add_key_values(component, self.EXPERIMENT_TECHNOLOGY_PAIRS)

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 
 from builtins import str
-from builtins import zip
 from builtins import range
 from builtins import object
 from argparse import ArgumentParser
@@ -37,8 +36,10 @@ KEYS = (
     Key('Study Publication Title', 'Study', optional=True, multiple=True),
     Key('Study Author List', 'Study', optional=True, multiple=True),
     Key('Study Organism', 'Study', optional=True, multiple=True),
-    Key('Study Organism Term Source REF', 'Study', optional=True, multiple=True),
-    Key('Study Organism Term Accession', 'Study', optional=True, multiple=True),
+    Key('Study Organism Term Source REF', 'Study', optional=True,
+        multiple=True),
+    Key('Study Organism Term Accession', 'Study', optional=True,
+        multiple=True),
     # OPTIONAL_KEYS["Study"]
     Key('Study Version History', 'Study', optional=True),
     Key('Study BioStudies Accession', 'Study', optional=True),
@@ -76,8 +77,10 @@ KEYS = (
     Key('Experiment Data DOI', 'Experiment', optional=True),
     Key("Experiment Data Publisher", 'Experiment', optional=True),
     Key('Experiment Organism', 'Experiment', optional=True, multiple=True),
-    Key('Experiment Organism Term Source REF', 'Experiment', optional=True, multiple=True),
-    Key('Experiment Organism Term Accession', 'Experiment', optional=True, multiple=True),
+    Key('Experiment Organism Term Source REF', 'Experiment', optional=True,
+        multiple=True),
+    Key('Experiment Organism Term Accession', 'Experiment', optional=True,
+        multiple=True),
     # MANDATORY_KEYS["Screen"]
     Key(r'Comment\[IDR Screen Name\]', 'Screen'),
     Key('Screen Description', 'Screen'),
@@ -90,8 +93,10 @@ KEYS = (
     Key('Screen Data Publisher', 'Screen', optional=True),
     Key('Screen Technology Type', 'Screen', optional=True, multiple=True),
     Key('Screen Organism', 'Screen', optional=True, multiple=True),
-    Key('Screen Organism Term Source REF', 'Screen', optional=True, multiple=True),
-    Key('Screen Organism Term Accession', 'Screen', optional=True, multiple=True),
+    Key('Screen Organism Term Source REF', 'Screen', optional=True,
+        multiple=True),
+    Key('Screen Organism Term Accession', 'Screen', optional=True,
+        multiple=True),
 )
 
 DOI_PATTERN = re.compile(
@@ -223,7 +228,7 @@ class StudyParser(object):
         authors = self.study.get('Study Author List', [])
         assert len(titles) == len(authors), (
             "Mismatching publication titles and authors")
-        
+
         for doi in self.study.get("Study DOI", []):
             validate_doi(doi)
 
@@ -489,7 +494,8 @@ class OMEROFormatter(object):
         if titles == [''] and authorlists == ['']:
             return []
 
-        for it in itertools.zip_longest(titles, authorlists, pubmeds, pmcs, dois):
+        for it in itertools.zip_longest(
+                titles, authorlists, pubmeds, pmcs, dois):
             title, authorlist, pubmed, pmc, doi = it
             publication = {"Title": title, "Author List": authorlist}
             if pubmed:
@@ -511,7 +517,6 @@ class OMEROFormatter(object):
                         s.append({name: value})
                 else:
                     self.log.debug("Missing key %s" % key)
-
 
         def format_key_values(d, pairs):
             for name, formatter in pairs:

--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -253,7 +253,8 @@ class StudyParser(object):
     def get_study_name(self):
         study_name = None
         for component in self.components:
-            name = component[r"Comment\[IDR %s Name\]" % self.get_component_type(component)]
+            key = "Comment[IDR %s Name]" % self.get_component_type(component)
+            name = component[key]
             if study_name is None:
                 study_name = name.split("/")[0]
             else:
@@ -298,7 +299,6 @@ class JSONFormatter(object):
                     continue
                 d[key] = value
             self.m["%ss" % component_type].append(d)
-
 
     def __str__(self):
         return json.dumps(self.m, indent=4, sort_keys=True)
@@ -383,7 +383,8 @@ class OMEROFormatter(object):
             if doi:
                 component["Data DOI"] = doi
             if "%s Organism" % component["Type"] not in component:
-                component["%s Organism" % component["Type"]] = component["Study Organism"]
+                organism_key = "%s Organism" % component["Type"]
+                component[organism_key] = component["Study Organism"]
             d = {
               "name": name,
               "description": self.generate_description(component),

--- a/test/test_study_parser.py
+++ b/test/test_study_parser.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from pyidr.study_parser import StudyParser
+from pyidr.study_parser import validate_doi
 import pytest
 
 
@@ -14,7 +14,7 @@ class TestDOI(object):
     ]
 
     def test_missing_key(self):
-        assert StudyParser.parse_data_doi({}, 'Study DOI') == {}
+        assert validate_doi(None) == None
 
     @pytest.mark.parametrize('doi', (
         'https://doi.org/10.17867/10000134',
@@ -22,23 +22,13 @@ class TestDOI(object):
         'http://doi.org/10.17867/10000134',
         'http://dx.doi.org/10.17867/10000134'))
     def test_doi_url_prefixes(self, doi):
-        d = {'Study DOI': doi}
-        assert StudyParser.parse_data_doi(d, 'Study DOI') == {
-            'Data DOI': '10.17867/10000134'}
+        assert validate_doi(doi) == '10.17867/10000134'
 
     def test_invalid_doi_link(self):
-        d = {'Study DOI': 'doi.org/10.17867/10000134'}
         with pytest.raises(Exception):
-            StudyParser.parse_data_doi(d, 'Study DOI')
+            validate_doi('doi.org/10.17867/10000134')
 
     @pytest.mark.parametrize('doi', VALID_DOIS)
-    def test_valid_doi_names(self, doi):
-        d = {'Study DOI': 'https://doi.org/%s' % doi}
-        assert StudyParser.parse_data_doi(d, 'Study DOI') == {
-            'Data DOI': doi}
-
-    @pytest.mark.parametrize('doi', VALID_DOIS)
-    def test_valid_doi_urls(self, doi):
-        d = {'Study DOI': doi}
-        assert StudyParser.parse_data_doi(d, 'Study DOI') == {
-            'Data DOI': doi}
+    def test_valid_dois(self, doi):
+        assert validatate_doi(doi) == doi
+        assert validatate_doi('https://doi.org/%s' % doi) == doi

--- a/test/test_study_parser.py
+++ b/test/test_study_parser.py
@@ -14,7 +14,7 @@ class TestDOI(object):
     ]
 
     def test_missing_key(self):
-        assert validate_doi(None) == None
+        assert validate_doi(None) is None
 
     @pytest.mark.parametrize('doi', (
         'https://doi.org/10.17867/10000134',
@@ -30,5 +30,5 @@ class TestDOI(object):
 
     @pytest.mark.parametrize('doi', VALID_DOIS)
     def test_valid_dois(self, doi):
-        assert validatate_doi(doi) == doi
-        assert validatate_doi('https://doi.org/%s' % doi) == doi
+        assert validate_doi(doi) == doi
+        assert validate_doi('https://doi.org/%s' % doi) == doi


### PR DESCRIPTION
As part of the ongoing investigation around landing pages, this PR reviews the `study_parser` utility which contains most of the logic to parse the study file and generate the OMERO annotations at the Project/Screen level. The main limitation at the moment is the outcome of the `--report` option is very tailored to the way the OMERO annotations are constructed.

To achiebe this, this PR focuses on separating the file parsing logic from the formatting logic to allow us to create different representations:

- the `Parser` class now generates an internal representation of the study as close as possible to the content of the study file with known keys defined in `KEYS` parsed, validated when applicable and stored either under the `study` dictionary or the `components` list (ordered list of screens/experiments).
- the four keys `Study Accession`, `Study Name`, `Experiment Name` and `Screen Name` keys are derived from internal keys named `Comment.*`
- keys with multiple values e.g. `Study Publication Title` are now split in the parser as list of strings and the downstream method adjusted accordingly
- the `Formatter` class is renamed as `OMEROFormatter` and all the OMERO-specific logic is migrated there
- a new `JSONFormatter` class is added which creates a minimal JSON representation of a study. Initially all the `Study` keys at the top-level and two `Experiments` and `Screens` elements which contain each of the study components
- the `--report` option is adjusted to use the JSONFormatter. A new `--report-directory` option allows to write the output of the formatter under `<out_dir>/<accession>.json` - see the artifacts https://github.com/IDR/idr-metadata/actions/runs/1745648670 
- The `--check/--set` options are unchanged and still work on OMERO objects using the OMEROFormatter


Potential next steps:

- improve the JSON representation of the study, add JSON-LD concepts
- add support for additional keys in the study file (`Protocols,` Feature...`)