### PR TITLE
Add Sample Type to stats.py output

### DIFF
--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -276,7 +276,6 @@ def stat_top_level(client, study_list, *, release, fsusage, append_totals):
         "Container",
         "Introduced",
         "ID",  # "Internal ID"
-        "Sample Type",   # cell or tissue
         "Set",  # Number of plates or datasets
         "Wells",
         "Experiments",
@@ -294,6 +293,7 @@ def stat_top_level(client, study_list, *, release, fsusage, append_totals):
         "# of Files",
         "avg. size (MB)",
         "Avg. Image Dim (XYZCT)",
+        "Sample Type",   # cell or tissue
     ))
 
     # Placeholders:
@@ -324,7 +324,6 @@ def stat_top_level(client, study_list, *, release, fsusage, append_totals):
                     container2,
                     release,
                     "MISSING",
-                    "",
                     0,
                     0,
                     experiments,
@@ -336,6 +335,7 @@ def stat_top_level(client, study_list, *, release, fsusage, append_totals):
                     0,
                     None,
                     None,
+                    "",
                     "",
                 )
             else:
@@ -375,7 +375,6 @@ def stat_top_level(client, study_list, *, release, fsusage, append_totals):
                         container2,
                         release,
                         plate_or_dataset_id,
-                        kv_pairs.get("Sample Type", ""),
                         plate_or_datasets,
                         wells,
                         experiments,
@@ -388,6 +387,7 @@ def stat_top_level(client, study_list, *, release, fsusage, append_totals):
                         fs_num,
                         fs_avg_size,
                         avg_image_dim,
+                        kv_pairs.get("Sample Type", ""),
                     )
 
     if append_totals:


### PR DESCRIPTION
This adds `Sample Type` to the `stats.py` output (used to generate https://github.com/IDR/idr.openmicroscopy.org/blob/master/_data/studies.tsv).

To test on a single IDR study:
```
$ omero login
$ git clone git@github.com:IDR/idr0101-payne-insitugenomeseq.git
$ python path/to/idr-utils/scripts/stats.py --disable-fsusage
Using session for public@idr.openmicroscopy.org:4064. Idle timeout: 10 min. Current group: Public
idr0101-payne-insitugenomeseq	experimentA	TODO	2051	cell	25	0			0	156	216523	0.576208039928	576208039928			788 x 786 x 20 x 6 x 15
idr0101-payne-insitugenomeseq	experimentB	TODO	2052	tissue	57	0			0	284	2692253	10.075314787152	10075314787152			1378 x 1377 x 188 x 5 x 12

```

cc @sbesson 