### PR TITLE
Remove Publication Title from description in study_parser.py

### DIFF
--- a/pyidr/study_parser.py
+++ b/pyidr/study_parser.py
@@ -405,25 +405,18 @@ class Formatter(object):
 
     def generate_description(self, component):
         """Generate the description of the study/experiment/screen"""
-        publication_title = ""
-        if component["Study Publication Title"]:
-            # Only display the first publication
-            publication_title = (
-                "Publication Title\n%(Study Publication Title)s" %
-                component).split('\t')[0] + "\n\n"
         if "Type" in component:
             key = "%s Description" % component["Type"]
         else:
             key = "Study Description"
-        component_title = (
-            "%s\n%s" % (key, component[key]))
+        component_title = component[key]
         if "Study Version History" in component:
             history = ("\n\nVersion History\n%s" %
                        component["Study Version History"])
         else:
             history = ""
 
-        return publication_title + component_title + history
+        return component_title + history
 
     def generate_annotation(self, component):
         """Generate the map annotation of the study/experiment/screen"""


### PR DESCRIPTION
See https://github.com/ome/omero-mapr/pull/74#issuecomment-1488563537

We want to simplify the Study `description` so that it can be parsed for searching, without duplicating the Study Title in the description.

