### PR TITLE
Add script to fix duplicated URLs annotations

### DIFF
--- a/scripts/annotate/fix_annotations.py
+++ b/scripts/annotate/fix_annotations.py
@@ -1,0 +1,71 @@
+import argparse
+import re
+
+import omero.cli
+
+parser = argparse.ArgumentParser(description="Generate SQL script to fix duplicated URL annotations")
+parser.add_argument("url", help="Regex of the URL to check for (incl a named group to match the ID!)"
+                                ", e.g. \".+ncbi\.nlm\.nih\.gov\/gene\/(?P<ID>.+)\"")
+parser.add_argument("namespace", help="The namespace of the annotations, e.g. openmicroscopy.org/mapr/gene")
+
+url_names = {"openmicroscopy.org/mapr/gene": "Gene Identifier URL",
+             "openmicroscopy.org/mapr/compound": "Compound Name URL"}
+
+pref_urls = [re.compile(r"^https:\/\/(?!www).+"),\
+             re.compile(r"^https:\/\/.+")] # prefer https:// without www over with www
+
+def load_annotations(conn, namespace):
+    metadataService = conn.getMetadataService()
+    annotations = metadataService.loadSpecifiedAnnotations(
+        'omero.model.MapAnnotation', [namespace], None, None)
+    for ann in annotations:
+        yield ann
+
+def get_urls(ann, pattern):
+    urls = []
+    ids = set()
+    symbol = ""
+    for nv in ann._mapValue:
+        if nv.name == url_names[ann._ns._val]:
+            m = pattern.match(nv.value)
+            if m:
+                urls.append(nv.value)
+                ids.add(m.group("ID"))
+        if "Symbol" in nv.name:
+            symbol = nv.value
+        elif "Name" in nv.name:
+            symbol = nv.value
+    if len(ids) > 1:
+        raise Exception(f"IDs don't match! ({ann._id._val}, {symbol}, {urls})")
+    return symbol, urls
+
+
+def check_annotations(conn, args):
+    pattern = re.compile(f"{args.url}")
+    for ann in load_annotations(conn, args.namespace):
+        symbol, urls = get_urls(ann, pattern)
+        if (len(urls) > 1):
+            url_to_keep = None
+            for url in urls:
+                for pref_url in pref_urls:
+                    if pref_url.match(url):
+                        url_to_keep = url
+                        break
+                if url_to_keep:
+                    break
+            if url_to_keep:
+                urls_to_delete = []
+                for url in urls:
+                    if url != url_to_keep:
+                        urls_to_delete.append(url)
+                print(f"-- Symbol: {symbol} - Annotation ID: {ann._id._val}")
+                print(f"-- URLs: {urls} - keep: {url_to_keep}")
+                for url in urls_to_delete:
+                    print(f"DELETE FROM annotation_mapvalue mv WHERE mv.annotation_id = {ann._id._val} AND mv.value = '{url}';\n")
+
+
+args = parser.parse_args()
+with omero.cli.cli_login() as c:
+    conn = omero.gateway.BlitzGateway(client_obj=c.get_client())
+    check_annotations(conn, args)
+


### PR DESCRIPTION
The script generates SQL commands to delete duplicated URLs.

E.g. to remove duplicated gene URLs like `http://ncbi...` / `https://ncbi...` run
`python fix_annotations.py ".+ncbi\.nlm\.nih\.gov\/gene\/(?P<ID>.+)" "openmicroscopy.org/mapr/gene"`

Output:
```
-- Symbol: FAM96B - Annotation ID: 6733961
-- URLs: ['https://www.ncbi.nlm.nih.gov/gene/51647', 'http://www.ncbi.nlm.nih.gov/gene/51647'] - keep: https://www.ncbi.nlm.nih.gov/gene/51647
DELETE FROM annotation_mapvalue mv WHERE mv.annotation_id = 6733961 AND mv.value = 'http://www.ncbi.nlm.nih.gov/gene/51647';

-- Symbol: TLR10 - Annotation ID: 6742661
-- URLs: ['https://www.ncbi.nlm.nih.gov/gene/81793', 'http://www.ncbi.nlm.nih.gov/gene/81793'] - keep: https://www.ncbi.nlm.nih.gov/gene/81793
DELETE FROM annotation_mapvalue mv WHERE mv.annotation_id = 6742661 AND mv.value = 'http://www.ncbi.nlm.nih.gov/gene/81793';
...
```

Tested on pilot-idr150, see for example gene annotation FAM96B
![Screenshot 2023-08-22 at 11 37 48](https://github.com/IDR/idr-utils/assets/6575139/eab655c2-c108-49f9-b074-fd4be64dae46)

IDR (https://idr.openmicroscopy.org/webclient/?show=image-12715003 ):
![Screenshot 2023-08-22 at 11 38 43](https://github.com/IDR/idr-utils/assets/6575139/ca6a0e6b-b0b2-4b7c-93d4-d2d5f63a7e47)

I've not tested it on compounds or other URLs yet.
