### PR TITLE
Log errors at logging.error() level

### DIFF
--- a/scripts/annotate/check_annotations.py
+++ b/scripts/annotate/check_annotations.py
@@ -193,7 +193,7 @@ if csv_keys:
                     " match any images:")
     for key in sorted(csv_keys):
         df.loc[csv_keys[key], "Errors"] = "No image"
-        logging.info("{},No image".format(key))
+        logging.warning("{},No image".format(key))
 
 if args.output:
     if args.skip_ok:


### PR DESCRIPTION
Having taken quite a long time to run `check_annotations.py` I get a not-very-helpful message:

```
"Missing annotation in csv file"
```

But no other info is provided.
I'm not sure why we would ever want that behaviour?

I had to look at the script code to find out how to get more info, since the SubmissionWorkflow doesn't tell me.

I try to rerun the script with `-v` flag to see `info` logging (another long time to run), but I get so much output that disappears off my terminal, and I can't scroll back to see it!!!

This PR means that we always log the *actual* errors so we know that after first run of the script.

cc @dominikl 