### PR TITLE
Add two missing mapr categories

### DIFF
--- a/scripts/annotate/clean_orphaned_maps.py
+++ b/scripts/annotate/clean_orphaned_maps.py
@@ -16,7 +16,9 @@ IMAGE_MAPS = {
     "Phenotype": "openmicroscopy.org/mapr/phenotype",
     "siRNA": "openmicroscopy.org/mapr/sirna",
     "Compound": "openmicroscopy.org/mapr/compound",
-    "Protein": "openmicroscopy.org/mapr/protein"
+    "Protein": "openmicroscopy.org/mapr/protein",
+    "ORF": "openmicroscopy.org/mapr/orf",
+    "OMAP": "openmicroscopy.org/mapr/OMAP"
     }
 
 CONTAINER_MAPS = {


### PR DESCRIPTION
Just noticed that there were two mapr categories missing from the cleanup script.
